### PR TITLE
Created the `BSScheduler` interface and added `LambdaBS` and `MultiplicativeBS`

### DIFF
--- a/bs_scheduler/__init__.py
+++ b/bs_scheduler/__init__.py
@@ -1,0 +1,5 @@
+from .batch_size_schedulers import LambdaBS, MultiplicativeBS
+
+__all__ = ['LambdaBS', 'MultiplicativeBS']
+
+del batch_size_schedulers

--- a/bs_scheduler/batch_size_schedulers.py
+++ b/bs_scheduler/batch_size_schedulers.py
@@ -29,23 +29,27 @@ class BSScheduler:
             if not hasattr(self.dataloader.dataset, "get_batch_size"):
                 # TODO: Validate the error name
                 raise KeyError("We require our users to implement a Callable[[], int] method named `get_batch_size` in "
-                               "their dataset which returns the current batch size.")
+                               "their dataset which returns the current batch size. Please see TODO for examples. ")
 
-        self._last_bs: Union[int, None] = None
         # See https://pytorch.org/docs/stable/_modules/torch/optim/lr_scheduler.html for "with_counter".
         self.last_epoch: int = 0
         self.base_bs: int = self.get_current_batch_size()
+        self._last_bs: int = self.base_bs
 
     def get_current_batch_size(self) -> int:
+        # TODO: Write documentation
         return self.dataloader.dataset.get_batch_size()
 
     def batch_sampler_get_current_batch_size(self) -> int:
+        # TODO: Write documentation
         return self.dataloader.batch_sampler.batch_size
 
     def set_batch_size(self, new_bs: int):
+        # TODO: Write documentation
         self.dataloader.dataset.change_batch_size(new_bs)
 
     def batch_sampler_set_batch_size(self, new_bs: int):
+        # TODO: Write documentation
         self.dataloader.batch_sampler.batch_size = new_bs
 
         # TODO: Read this:
@@ -87,7 +91,7 @@ class BSScheduler:
 
     def get_last_bs(self) -> int:
         """ Return last computed batch size by current scheduler. If called before the first call to :meth:`step`
-        returns None.
+        returns the base batch size.
         """
         # TODO: Check if it better to return dataloader.batch_size
         return self._last_bs
@@ -155,5 +159,5 @@ class LambdaBS(BSScheduler):
             self.bs_lambda.__dict__.update(bs_lambda)
 
     def get_bs(self) -> int:
-        # TODO: Check if we need to add warning if called outside of scheduler step.
+        # TODO: Write documentation
         return int(self.base_bs * self.bs_lambda(self.last_epoch))

--- a/bs_scheduler/batch_size_schedulers.py
+++ b/bs_scheduler/batch_size_schedulers.py
@@ -1,0 +1,71 @@
+# Inspired from https://pytorch.org/docs/stable/_modules/torch/optim/lr_scheduler.html.
+from typing import Callable
+
+from torch.utils.data import DataLoader
+
+__all__ = ['LambdaBS']
+
+
+class BSScheduler:
+    def __init__(self, dataloader):
+        # TODO: Finalize interface and documentation
+        if not isinstance(dataloader, DataLoader):
+            raise TypeError(f"{type(dataloader).__name__} is not a Dataloader")
+        self.dataloader = dataloader
+
+        self._last_bs = None
+        # See https://pytorch.org/docs/stable/_modules/torch/optim/lr_scheduler.html for "with_counter".
+
+    def state_dict(self) -> dict:
+        """Returns the state of the scheduler as a :class:`dict`.
+
+        It contains an entry for every variable in self.__dict__ which
+        is not the optimizer.
+        """
+        return {key: value for key, value in self.__dict__.items() if key != 'dataloader'}
+
+    def load_state_dict(self, state_dict: dict):
+        """Loads the schedulers state.
+
+        Args:
+            state_dict (dict): scheduler state. Should be an object returned
+                from a call to :meth:`state_dict`.
+        """
+        self.__dict__.update(state_dict)
+
+    def get_last_bs(self) -> int:
+        """ Return last computed batch size by current scheduler. If called before the first call to :meth:`step`
+        returns None.
+        """
+        # TODO: Check if it better to return dataloader.batch_size
+        return self._last_bs
+
+    def _get_bs(self) -> int:
+        """ Computes the next batch size. Should not be called explicitly in client code. """
+        raise NotImplementedError
+
+    def step(self):
+        # TODO: Documentation + implementation
+        pass
+
+
+class LambdaBS(BSScheduler):
+    """ Sets the batch size to the initial batch size times a given function. Unlike torch.optim.lr_scheduler.LambdaLR,
+    there is a single batch size for a given dataloader so only one function should be given.
+
+    Args:
+        dataloader (DataLoader): Wrapped dataloader.
+        bs_lambda: (Callable[[int], int]): A function which computes a multiplicative factor given an integer parameter
+            epoch.
+
+    Example:
+        >>> dataloader = ...
+        >>> func = lambda epoch: int(100 * 1.05 ** epoch)
+        >>> scheduler = LambdaBS(dataloader, bs_lambda=func)
+        >>> for epoch in range(100):
+        >>>     train(...)
+        >>>     validate(...)
+        >>>     scheduler.step()
+    """
+    def __init__(self, dataloader: DataLoader, bs_lambda: Callable[[int], int]):
+        pass

--- a/bs_scheduler/batch_size_schedulers.py
+++ b/bs_scheduler/batch_size_schedulers.py
@@ -114,7 +114,7 @@ class BSScheduler:
         return {key: value for key, value in self.__dict__.items() if key != 'dataloader'}
 
     def load_state_dict(self, state_dict: dict):
-        """Loads the schedulers state.
+        """ Loads the schedulers state.
 
         Args:
             state_dict (dict): scheduler state. Should be an object returned from a call to :meth:`state_dict`.
@@ -123,7 +123,7 @@ class BSScheduler:
         self.set_batch_size(self.get_last_bs())  # Setting the batch size to the last computed batch size.
 
     def get_last_bs(self) -> int:
-        """ Return last computed batch size by current scheduler. If called before the first call to :meth:`step`
+        """ Returns the last computed batch size by current scheduler. If called before the first call to :meth:`step`
         returns the base batch size.
         """
         return self._last_bs
@@ -137,7 +137,7 @@ class BSScheduler:
             print(f'Adjusting batch size to {new_bs}')
 
     def step(self):
-        # TODO: Documentation + implementation
+        # TODO: Documentation
         # TODO: Check how the dataloader behaves if we change the batch size mid epoch. Write a guideline for this.
         #  Changing the batch size does not impact batch sizes loaded by workers before the change.
         # TODO: Check if changing the batch size needs locking. Because of multiprocessing. Normally it should not.
@@ -157,8 +157,8 @@ class LambdaBS(BSScheduler):
         bs_lambda (Callable[[int], float]): A function which computes a multiplicative factor given an integer
             parameter epoch.
         max_batch_size (Union[int, None]): Upper limit for the batch size so that a batch of size max_batch_size fits
-            in the memory. If None or greate than the lenght of the dataset wrapped by the dataloader, max_batch_size is
-             set to `len(self.dataloader.dataset)`. Default: None.
+            in the memory. If None or greater than the lenght of the dataset wrapped by the dataloader, max_batch_size
+            is set to `len(self.dataloader.dataset)`. Default: None.
         min_batch_size (int): Lower limit for the batch size which must be greater than 0. Default: 1.
         verbose (bool): If ``True``, prints a message to stdout for each update. Default: ``False``.
 
@@ -219,15 +219,15 @@ class MultiplicativeBS(BSScheduler):
         bs_lambda: (Callable[[int], float]): A function which computes a multiplicative factor given an integer
             parameter epoch.
         max_batch_size (Union[int, None]): Upper limit for the batch size so that a batch of size max_batch_size fits
-            in the memory. If None or greate than the lenght of the dataset wrapped by the dataloader, max_batch_size is
-             set to `len(self.dataloader.dataset)`. Default: None.
+            in the memory. If None or greater than the lenght of the dataset wrapped by the dataloader, max_batch_size
+            is set to `len(self.dataloader.dataset)`. Default: None.
         min_batch_size (int): Lower limit for the batch size which must be greater than 0. Default: 1.
         verbose (bool): If ``True``, prints a message to stdout for each update. Default: ``False``.
 
     Example:
         >>> dataloader = ...
         >>> func = lambda epoch: 1.05
-        >>> scheduler = LambdaBS(dataloader, bs_lambda=func)
+        >>> scheduler = MultiplicativeBS(dataloader, bs_lambda=func)
         >>> for epoch in range(100):
         >>>     train(...)
         >>>     validate(...)

--- a/bs_scheduler/batch_size_schedulers.py
+++ b/bs_scheduler/batch_size_schedulers.py
@@ -15,7 +15,9 @@ class BSScheduler:
             raise TypeError(f"{type(dataloader).__name__} is not a Dataloader")
         self.dataloader: DataLoader = dataloader
 
-        self.max_batch_size: int = len(self.dataloader.dataset) if max_batch_size is None else max_batch_size
+        self.max_batch_size: int = len(self.dataloader.dataset)
+        if max_batch_size is not None:
+            self.max_batch_size = min(self.max_batch_size, max_batch_size)
         assert min_batch_size > 0, f"Minimum batch size must be greater than 0, is {min_batch_size}"
         assert min_batch_size <= self.max_batch_size, f"Minimum batch size ({min_batch_size}) must be smaller or equal " \
                                                       f"than maximum batch size ({self.max_batch_size})"
@@ -127,8 +129,8 @@ class LambdaBS(BSScheduler):
         bs_lambda (Callable[[int], float]): A function which computes a multiplicative factor given an integer
             parameter epoch.
         max_batch_size (Union[int, None]): Upper limit for the batch size so that a batch of size max_batch_size fits
-            in the memory. If None, max_batch_size is set to the lenght of the dataset wrapped by the dataloader.
-            Default: None.
+            in the memory. If None or greate than the lenght of the dataset wrapped by the dataloader, max_batch_size is
+             set to `len(self.dataloader.dataset)`. Default: None.
         min_batch_size (int): Lower limit for the batch size which must be greater than 0. Default: 1.
 
     Example:
@@ -185,8 +187,8 @@ class MultiplicativeBS(BSScheduler):
         bs_lambda: (Callable[[int], float]): A function which computes a multiplicative factor given an integer
             parameter epoch.
         max_batch_size (Union[int, None]): Upper limit for the batch size so that a batch of size max_batch_size fits
-            in the memory. If None, max_batch_size is set to the lenght of the dataset wrapped by the dataloader.
-            Default: None.
+            in the memory. If None or greate than the lenght of the dataset wrapped by the dataloader, max_batch_size is
+             set to `len(self.dataloader.dataset)`. Default: None.
         min_batch_size (int): Lower limit for the batch size which must be greater than 0. Default: 1.
         TODO: Add verbose
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ keywords = [
     'dynamic batch size'
 ]
 dependencies = [
-    "torch", # TODO: check version in which dataloader was updated
+    "torch>=1.1.0",
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "bs_scheduler"
-version = "0.0.1"
+version = "0.1.0"
 requires-python = ">=3.9"
 description = "A PyTorch Dataloader compatible batch size scheduler library."
 readme = "README.md"

--- a/tests/test_LambdaBS.py
+++ b/tests/test_LambdaBS.py
@@ -1,16 +1,45 @@
+import math
 import unittest
 
 from torch.optim.lr_scheduler import LambdaLR
 
+from bs_scheduler.batch_size_schedulers import LambdaBS
+from tests.test_utils import create_dataloader, dataloader_len, step_n_epochs
+
 
 class TestLambdaBS(unittest.TestCase):
     def setUp(self):
-        pass
+        self.batch_size = 64
+        self.dataloader = create_dataloader(batch_size=self.batch_size)
+        self.dataset_len = len(self.dataloader.dataset)
 
-    def test_true(self):
-        x = LambdaLR()
-        x = x.step()
-        self.assertTrue(True)
+    def assert_real_eq_inferred(self, real, inferred):
+        self.assertEqual(real, inferred, "Dataloader __len__ does not return the real length. The real length should "
+                                         "always be equal to the inferred length except for Iterable Datasets for "
+                                         "which the __len__ could be inaccurate.")
+
+    def assert_real_eq_expected(self, real, expected):
+        self.assertEqual(real, expected, f"Expected {expected}, got {real}")
+
+    def test_sanity(self):
+        real, inferred = dataloader_len(self.dataloader)
+        self.assert_real_eq_inferred(real, inferred)
+
+        self.dataloader.batch_sampler.batch_size = 32
+        real, inferred = dataloader_len(self.dataloader)
+        self.assert_real_eq_inferred(real, inferred)
+
+    def test_dataloader_lengths(self):
+        fn = lambda epoch: (1 + epoch) ** 1.05
+        self.scheduler = LambdaBS(self.dataloader, fn)
+        n_epochs = 3
+
+        lengths = step_n_epochs(self.dataloader, self.scheduler, n_epochs)
+
+        expected_batch_sizes = [int(self.batch_size * fn(epoch)) for epoch in range(n_epochs)]
+        expected_lengths = [int(math.ceil(self.dataset_len / bs)) for bs in expected_batch_sizes]
+
+        self.assert_real_eq_expected(lengths, expected_lengths)
 
 
 if __name__ == "__main__":

--- a/tests/test_LambdaBS.py
+++ b/tests/test_LambdaBS.py
@@ -14,8 +14,7 @@ class TestLambdaBS(BSTest):
 
     @staticmethod
     def compute_expected_batch_sizes(epochs, base_batch_size, fn, min_batch_size, max_batch_size):
-        return [base_batch_size] + [clip(int(base_batch_size * fn(epoch)), min_batch_size, max_batch_size) for
-                                    epoch in range(1, epochs)]
+        return [clip(int(base_batch_size * fn(epoch)), min_batch_size, max_batch_size) for epoch in range(epochs)]
 
     def test_sanity(self):
         dataloader = create_dataloader(self.dataset, batch_size=self.base_batch_size)

--- a/tests/test_LambdaBS.py
+++ b/tests/test_LambdaBS.py
@@ -28,7 +28,7 @@ class TestLambdaBS(unittest.TestCase):
         real, inferred = iterate(dataloader)
         self.assert_real_eq_inferred(real, inferred)
 
-        dataloader.batch_sampler.batch_size = 32
+        dataloader.batch_sampler.batch_size = 256
         real, inferred = iterate(dataloader)
         self.assert_real_eq_inferred(real, inferred)
 

--- a/tests/test_LambdaBS.py
+++ b/tests/test_LambdaBS.py
@@ -1,0 +1,20 @@
+import unittest
+
+from torch.optim.lr_scheduler import LambdaLR
+
+
+class TestLambdaBS(unittest.TestCase):
+    def setUp(self):
+        pass
+
+    def test_true(self):
+        x = LambdaLR()
+        x = x.step()
+        self.assertTrue(True)
+
+
+if __name__ == "__main__":
+    from multiprocessing import freeze_support
+
+    freeze_support()
+    unittest.main()

--- a/tests/test_MultiplicativeBS.py
+++ b/tests/test_MultiplicativeBS.py
@@ -1,20 +1,25 @@
-import math
 import unittest
 
-from bs_scheduler.batch_size_schedulers import MultiplicativeBS
-from tests.test_utils import create_dataloader, iterate, simulate_n_epochs, fashion_mnist, \
-    get_batch_sizes_across_epochs
+from bs_scheduler import MultiplicativeBS
+from tests.test_utils import create_dataloader, simulate_n_epochs, fashion_mnist, \
+    get_batch_sizes_across_epochs, BSTest, clip
 
 
-class TestMultiplicativeBS(unittest.TestCase):
+class TestMultiplicativeBS(BSTest):
     def setUp(self):
         self.base_batch_size = 64
         self.dataset = fashion_mnist()
         # TODO: Test multiple dataloaders: dataloader with workers, dataloaders with samplers, with drop last and
         #  without drop last and so on.
 
-    def assert_real_eq_expected(self, real, expected):
-        self.assertEqual(real, expected, f"Expected {expected}, got {real}")
+    @staticmethod
+    def compute_expected_batch_sizes(epochs, base_batch_size, fn, min_batch_size, max_batch_size):
+        expected_batch_sizes = [base_batch_size]
+        for epoch in range(1, epochs):
+            batch_size = int(expected_batch_sizes[-1] * fn(epoch))
+            batch_size = clip(batch_size, min_batch_size, max_batch_size)
+            expected_batch_sizes.append(batch_size)
+        return expected_batch_sizes
 
     def test_dataloader_lengths(self):
         dataloader = create_dataloader(self.dataset, batch_size=self.base_batch_size)
@@ -23,22 +28,21 @@ class TestMultiplicativeBS(unittest.TestCase):
         n_epochs = 300
 
         epoch_lengths = simulate_n_epochs(dataloader, scheduler, n_epochs)
-        expected_batch_sizes = [self.base_batch_size]
-        for epoch in range(n_epochs):
-            expected_batch_sizes.append(int(expected_batch_sizes[-1] * fn(epoch)))
-        expected_batch_sizes.pop(0)  # Removing first
-        expected_lengths = [int(math.ceil(len(self.dataset) / bs)) for bs in expected_batch_sizes]
+        expected_batch_sizes = self.compute_expected_batch_sizes(n_epochs, self.base_batch_size, fn,
+                                                                 scheduler.min_batch_size, scheduler.max_batch_size)
+        expected_lengths = self.compute_epoch_lengths(expected_batch_sizes, len(self.dataset), drop_last=False)
 
         self.assert_real_eq_expected(epoch_lengths, expected_lengths)
 
     def test_dataloader_batch_size(self):
         dataloader = create_dataloader(self.dataset, batch_size=self.base_batch_size)
-        fn = lambda epoch: epoch / 100 + 1
+        fn = lambda epoch: epoch / 100 + 2
         scheduler = MultiplicativeBS(dataloader, fn)
-        n_epochs = 300
+        n_epochs = 15
 
         batch_sizes = get_batch_sizes_across_epochs(dataloader, scheduler, n_epochs)
-        expected_batch_sizes = [int(self.base_batch_size * fn(epoch)) for epoch in range(n_epochs)]
+        expected_batch_sizes = self.compute_expected_batch_sizes(n_epochs, self.base_batch_size, fn,
+                                                                 scheduler.min_batch_size, scheduler.max_batch_size)
 
         self.assert_real_eq_expected(batch_sizes, expected_batch_sizes)
 

--- a/tests/test_MultiplicativeBS.py
+++ b/tests/test_MultiplicativeBS.py
@@ -37,7 +37,7 @@ class TestMultiplicativeBS(BSTest):
     def test_dataloader_batch_size(self):
         dataloader = create_dataloader(self.dataset, batch_size=self.base_batch_size)
         fn = lambda epoch: epoch / 100 + 2
-        scheduler = MultiplicativeBS(dataloader, fn)
+        scheduler = MultiplicativeBS(dataloader, fn, max_batch_size=5000)
         n_epochs = 15
 
         batch_sizes = get_batch_sizes_across_epochs(dataloader, scheduler, n_epochs)

--- a/tests/test_MultiplicativeBS.py
+++ b/tests/test_MultiplicativeBS.py
@@ -14,11 +14,12 @@ class TestMultiplicativeBS(BSTest):
 
     @staticmethod
     def compute_expected_batch_sizes(epochs, base_batch_size, fn, min_batch_size, max_batch_size):
-        expected_batch_sizes = [base_batch_size]
-        for epoch in range(1, epochs):
+        expected_batch_sizes = [base_batch_size]  # Base batch size is added as a boundary condition.
+        for epoch in range(epochs):
             batch_size = int(expected_batch_sizes[-1] * fn(epoch))
             batch_size = clip(batch_size, min_batch_size, max_batch_size)
             expected_batch_sizes.append(batch_size)
+        expected_batch_sizes.pop(0)  # Removing base batch size.
         return expected_batch_sizes
 
     def test_dataloader_lengths(self):
@@ -37,7 +38,7 @@ class TestMultiplicativeBS(BSTest):
     def test_dataloader_batch_size(self):
         dataloader = create_dataloader(self.dataset, batch_size=self.base_batch_size)
         fn = lambda epoch: epoch / 100 + 2
-        scheduler = MultiplicativeBS(dataloader, fn, max_batch_size=5000)
+        scheduler = MultiplicativeBS(dataloader, fn, max_batch_size=5000, verbose=False)
         n_epochs = 15
 
         batch_sizes = get_batch_sizes_across_epochs(dataloader, scheduler, n_epochs)

--- a/tests/test_MultiplicativeBS.py
+++ b/tests/test_MultiplicativeBS.py
@@ -1,0 +1,50 @@
+import math
+import unittest
+
+from bs_scheduler.batch_size_schedulers import MultiplicativeBS
+from tests.test_utils import create_dataloader, iterate, simulate_n_epochs, fashion_mnist, \
+    get_batch_sizes_across_epochs
+
+
+class TestMultiplicativeBS(unittest.TestCase):
+    def setUp(self):
+        self.base_batch_size = 64
+        self.dataset = fashion_mnist()
+        # TODO: Test multiple dataloaders: dataloader with workers, dataloaders with samplers, with drop last and
+        #  without drop last and so on.
+
+    def assert_real_eq_expected(self, real, expected):
+        self.assertEqual(real, expected, f"Expected {expected}, got {real}")
+
+    def test_dataloader_lengths(self):
+        dataloader = create_dataloader(self.dataset, batch_size=self.base_batch_size)
+        fn = lambda epoch: epoch / 100 + 1
+        scheduler = MultiplicativeBS(dataloader, fn)
+        n_epochs = 300
+
+        epoch_lengths = simulate_n_epochs(dataloader, scheduler, n_epochs)
+        expected_batch_sizes = [self.base_batch_size]
+        for epoch in range(n_epochs):
+            expected_batch_sizes.append(int(expected_batch_sizes[-1] * fn(epoch)))
+        expected_batch_sizes.pop(0)  # Removing first
+        expected_lengths = [int(math.ceil(len(self.dataset) / bs)) for bs in expected_batch_sizes]
+
+        self.assert_real_eq_expected(epoch_lengths, expected_lengths)
+
+    def test_dataloader_batch_size(self):
+        dataloader = create_dataloader(self.dataset, batch_size=self.base_batch_size)
+        fn = lambda epoch: epoch / 100 + 1
+        scheduler = MultiplicativeBS(dataloader, fn)
+        n_epochs = 300
+
+        batch_sizes = get_batch_sizes_across_epochs(dataloader, scheduler, n_epochs)
+        expected_batch_sizes = [int(self.base_batch_size * fn(epoch)) for epoch in range(n_epochs)]
+
+        self.assert_real_eq_expected(batch_sizes, expected_batch_sizes)
+
+
+if __name__ == "__main__":
+    from multiprocessing import freeze_support
+
+    freeze_support()
+    unittest.main()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -3,21 +3,25 @@ from torchvision.transforms import ToTensor
 from torch.utils.data import DataLoader
 
 
-def create_dataloader(num_workers=0, batch_size=64):
-    dataset = datasets.FashionMNIST(
+def fashion_mnist():
+    return datasets.FashionMNIST(
         root="data",
         train=True,
         download=True,
         transform=ToTensor()
     )
+
+
+def create_dataloader(dataset, num_workers=0, batch_size=64, drop_last=False):
     shuffle = True  # shuffle or sampler
     batch_sampler = None  # Sampler or None
+    sampler = None
     # Collate fn is default_convert when batch size and batch sampler are not defined, else default_collate
     return DataLoader(dataset, batch_size=batch_size, shuffle=shuffle, batch_sampler=batch_sampler,
-                      num_workers=num_workers)
+                      num_workers=num_workers, drop_last=drop_last, sampler=sampler)
 
 
-def dataloader_len(dataloader):
+def iterate(dataloader):
     inferred_len = len(dataloader)  # TODO: review name
     real_len = 0
     for _ in dataloader:
@@ -25,9 +29,20 @@ def dataloader_len(dataloader):
     return real_len, inferred_len
 
 
-def step_n_epochs(dataloader, scheduler, epochs):
+def simulate_n_epochs(dataloader, scheduler, epochs):
     lengths = []
     for _ in range(epochs):
         lengths.append(len(dataloader))
         scheduler.step()
     return lengths
+
+def get_batch_size(dataloader):
+    return len(next(iter(dataloader))[0])
+
+
+def get_batch_sizes_across_epochs(dataloader, scheduler, epochs):
+    batch_sizes = []
+    for _ in range(epochs):
+        batch_sizes.append(get_batch_size(dataloader))
+        scheduler.step()
+    return batch_sizes

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,3 +1,4 @@
+import torch
 from torchvision import datasets
 from torchvision.transforms import ToTensor
 from torch.utils.data import DataLoader
@@ -36,8 +37,16 @@ def simulate_n_epochs(dataloader, scheduler, epochs):
         scheduler.step()
     return lengths
 
+
 def get_batch_size(dataloader):
-    return len(next(iter(dataloader))[0])
+    data = next(iter(dataloader))
+    if isinstance(data, torch.Tensor):
+        return len(data)
+    if isinstance(data, (list, tuple)):
+        return len(data[0])
+    if isinstance(data, dict):
+        return len(next(iter(data.values())))
+    raise TypeError(f"Unknown type {type(data).__name__}")
 
 
 def get_batch_sizes_across_epochs(dataloader, scheduler, epochs):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,3 +1,6 @@
+import math
+import unittest
+
 import torch
 from torchvision import datasets
 from torchvision.transforms import ToTensor
@@ -55,3 +58,23 @@ def get_batch_sizes_across_epochs(dataloader, scheduler, epochs):
         batch_sizes.append(get_batch_size(dataloader))
         scheduler.step()
     return batch_sizes
+
+
+def clip(x, min_x, max_x):
+    return min(max(x, min_x), max_x)
+
+
+class BSTest(unittest.TestCase):
+    def assert_real_eq_inferred(self, real, inferred):
+        self.assertEqual(real, inferred, "Dataloader __len__ does not return the real length. The real length should "
+                                         "always be equal to the inferred length except for Iterable Datasets for "
+                                         "which the __len__ could be inaccurate.")
+
+    def assert_real_eq_expected(self, real, expected):
+        self.assertEqual(real, expected, f"Expected {expected}, got {real}")
+
+    @staticmethod
+    def compute_epoch_lengths(batch_sizes, dataset_len, drop_last):
+        if drop_last:
+            return [dataset_len // bs for bs in batch_sizes]
+        return [int(math.ceil(dataset_len / bs)) for bs in batch_sizes]

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,33 @@
+from torchvision import datasets
+from torchvision.transforms import ToTensor
+from torch.utils.data import DataLoader
+
+
+def create_dataloader(num_workers=0, batch_size=64):
+    dataset = datasets.FashionMNIST(
+        root="data",
+        train=True,
+        download=True,
+        transform=ToTensor()
+    )
+    shuffle = True  # shuffle or sampler
+    batch_sampler = None  # Sampler or None
+    # Collate fn is default_convert when batch size and batch sampler are not defined, else default_collate
+    return DataLoader(dataset, batch_size=batch_size, shuffle=shuffle, batch_sampler=batch_sampler,
+                      num_workers=num_workers)
+
+
+def dataloader_len(dataloader):
+    inferred_len = len(dataloader)  # TODO: review name
+    real_len = 0
+    for _ in dataloader:
+        real_len += 1
+    return real_len, inferred_len
+
+
+def step_n_epochs(dataloader, scheduler, epochs):
+    lengths = []
+    for _ in range(epochs):
+        lengths.append(len(dataloader))
+        scheduler.step()
+    return lengths


### PR DESCRIPTION
* `BSScheduler` is the base batch size scheduler class, all other batch size schedulers have to derive from it and implement the `get_bs` method. It implements methods to retrieve and modify the batch size from the wrapped `DataLoader` and the `step` method which is called in client code. 
* `LambdaBS` is a batch size scheduler which sets the value of the batch size to the base batch size times a user-given function. 
* `MultiplicativeBS` is a batch size scheduler which sets the value of the batch size to the current value of the batch size times a user-given function. 
* Added unittest files for both `LambdaBS` and `MultiplicativeBS`. 
* Changing version to `0.1.0`.