### PR TITLE
Added `StepB`, `MultiStepBS`, `ConstantBS`, `LinearBS`, `ExponentialBS`, `SequentialBS` batch size schedulers.

### DIFF
--- a/bs_scheduler/__init__.py
+++ b/bs_scheduler/__init__.py
@@ -1,7 +1,8 @@
-from .batch_size_schedulers import LambdaBS, MultiplicativeBS, StepBS, BSScheduler, BatchSizeManager
+from .batch_size_schedulers import LambdaBS, MultiplicativeBS, StepBS, MultiStepBS, BSScheduler, BatchSizeManager
+
 # We do not export DefaultBatchSizeManager and CustomBatchSizeManager because they are not needed. Users with custom
 # setups can create their own batch size managers.
 
-__all__ = ['LambdaBS', 'MultiplicativeBS', 'StepBS', 'BSScheduler', 'BatchSizeManager']
+__all__ = ['LambdaBS', 'MultiplicativeBS', 'StepBS', 'MultiStepBS', 'BSScheduler', 'BatchSizeManager']
 
 del batch_size_schedulers

--- a/bs_scheduler/__init__.py
+++ b/bs_scheduler/__init__.py
@@ -1,7 +1,7 @@
-from .batch_size_schedulers import LambdaBS, MultiplicativeBS, BSScheduler, BatchSizeManager
+from .batch_size_schedulers import LambdaBS, MultiplicativeBS, StepBS, BSScheduler, BatchSizeManager
 # We do not export DefaultBatchSizeManager and CustomBatchSizeManager because they are not needed. Users with custom
 # setups can create their own batch size managers.
 
-__all__ = ['LambdaBS', 'MultiplicativeBS', 'BSScheduler', 'BatchSizeManager']
+__all__ = ['LambdaBS', 'MultiplicativeBS', 'StepBS', 'BSScheduler', 'BatchSizeManager']
 
 del batch_size_schedulers

--- a/bs_scheduler/__init__.py
+++ b/bs_scheduler/__init__.py
@@ -1,10 +1,10 @@
-from .batch_size_schedulers import LambdaBS, MultiplicativeBS, StepBS, MultiStepBS, ConstantBS, LinearBS, BSScheduler, \
-    BatchSizeManager
+from .batch_size_schedulers import LambdaBS, MultiplicativeBS, StepBS, MultiStepBS, ConstantBS, LinearBS, ExponentialBS, \
+    BSScheduler, BatchSizeManager
 
 # We do not export DefaultBatchSizeManager and CustomBatchSizeManager because they are not needed. Users with custom
 # setups can create their own batch size managers.
 
-__all__ = ['LambdaBS', 'MultiplicativeBS', 'StepBS', 'MultiStepBS', 'ConstantBS', 'LinearBS', 'BSScheduler',
-           'BatchSizeManager']
+__all__ = ['LambdaBS', 'MultiplicativeBS', 'StepBS', 'MultiStepBS', 'ConstantBS', 'LinearBS', 'ExponentialBS',
+           'BSScheduler', 'BatchSizeManager']
 
 del batch_size_schedulers

--- a/bs_scheduler/__init__.py
+++ b/bs_scheduler/__init__.py
@@ -1,10 +1,10 @@
 from .batch_size_schedulers import LambdaBS, MultiplicativeBS, StepBS, MultiStepBS, ConstantBS, LinearBS, ExponentialBS, \
-    BSScheduler, BatchSizeManager
+    SequentialBS, BSScheduler, BatchSizeManager
 
 # We do not export DefaultBatchSizeManager and CustomBatchSizeManager because they are not needed. Users with custom
 # setups can create their own batch size managers.
 
 __all__ = ['LambdaBS', 'MultiplicativeBS', 'StepBS', 'MultiStepBS', 'ConstantBS', 'LinearBS', 'ExponentialBS',
-           'BSScheduler', 'BatchSizeManager']
+           'SequentialBS', 'BSScheduler', 'BatchSizeManager']
 
 del batch_size_schedulers

--- a/bs_scheduler/__init__.py
+++ b/bs_scheduler/__init__.py
@@ -1,9 +1,10 @@
-from .batch_size_schedulers import LambdaBS, MultiplicativeBS, StepBS, MultiStepBS, ConstantBS, BSScheduler, \
+from .batch_size_schedulers import LambdaBS, MultiplicativeBS, StepBS, MultiStepBS, ConstantBS, LinearBS, BSScheduler, \
     BatchSizeManager
 
 # We do not export DefaultBatchSizeManager and CustomBatchSizeManager because they are not needed. Users with custom
 # setups can create their own batch size managers.
 
-__all__ = ['LambdaBS', 'MultiplicativeBS', 'StepBS', 'MultiStepBS', 'ConstantBS', 'BSScheduler', 'BatchSizeManager']
+__all__ = ['LambdaBS', 'MultiplicativeBS', 'StepBS', 'MultiStepBS', 'ConstantBS', 'LinearBS', 'BSScheduler',
+           'BatchSizeManager']
 
 del batch_size_schedulers

--- a/bs_scheduler/__init__.py
+++ b/bs_scheduler/__init__.py
@@ -1,8 +1,9 @@
-from .batch_size_schedulers import LambdaBS, MultiplicativeBS, StepBS, MultiStepBS, BSScheduler, BatchSizeManager
+from .batch_size_schedulers import LambdaBS, MultiplicativeBS, StepBS, MultiStepBS, ConstantBS, BSScheduler, \
+    BatchSizeManager
 
 # We do not export DefaultBatchSizeManager and CustomBatchSizeManager because they are not needed. Users with custom
 # setups can create their own batch size managers.
 
-__all__ = ['LambdaBS', 'MultiplicativeBS', 'StepBS', 'MultiStepBS', 'BSScheduler', 'BatchSizeManager']
+__all__ = ['LambdaBS', 'MultiplicativeBS', 'StepBS', 'MultiStepBS', 'ConstantBS', 'BSScheduler', 'BatchSizeManager']
 
 del batch_size_schedulers

--- a/bs_scheduler/batch_size_schedulers.py
+++ b/bs_scheduler/batch_size_schedulers.py
@@ -465,7 +465,9 @@ class ConstantBS(BSScheduler):
     def get_bs(self) -> int:
         """ Returns the next batch size as an :class:`int`.
 
-        TODO: Documentation
+        The value of the batch size is changed once at initialization, when the batch size is multiplied with the given
+        factor, and twice when the milestone is reached and the batch size is multiplied with the inverse of the given
+        factor. The factor is adjusted during initialization such that it does not return a batch size out of bounds.
         """
         current_batch_size = self.get_current_batch_size()
 

--- a/bs_scheduler/batch_size_schedulers.py
+++ b/bs_scheduler/batch_size_schedulers.py
@@ -11,6 +11,12 @@ __all__ = ['LambdaBS', 'MultiplicativeBS', 'StepBS', 'MultiStepBS', 'ConstantBS'
            'BatchSizeManager']
 
 
+def rint(x: float) -> int:
+    """ Rounds to the nearest int and returns the value as int.
+    """
+    return int(round(x))
+
+
 def check_isinstance(x, instance: type):
     if not isinstance(x, instance):
         raise TypeError(f"{type(x).__name__} is not a {x.__name__}.")
@@ -123,6 +129,8 @@ class BSScheduler:
         self.dataloader: DataLoader = dataloader
         self.verbose: bool = verbose
 
+        assert max_batch_size is None or isinstance(max_batch_size, int)
+        assert isinstance(min_batch_size, int)
         if max_batch_size is None:
             self.max_batch_size: int = len(self.dataloader.dataset)
         else:
@@ -263,7 +271,7 @@ class LambdaBS(BSScheduler):
 
         It is calculated as the initial value of the batch size times the factor returned by `bs_lambda`.
         """
-        return int(self.base_bs * self.bs_lambda(self.last_epoch))
+        return rint(self.base_bs * self.bs_lambda(self.last_epoch))
 
 
 class MultiplicativeBS(BSScheduler):
@@ -329,7 +337,7 @@ class MultiplicativeBS(BSScheduler):
 
         It is calculated as the current value of the batch size times the factor returned by `bs_lambda`.
         """
-        return int(self.get_current_batch_size() * self.bs_lambda(self.last_epoch))
+        return rint(self.get_current_batch_size() * self.bs_lambda(self.last_epoch))
 
 
 class StepBS(BSScheduler):
@@ -379,7 +387,7 @@ class StepBS(BSScheduler):
         """
         if self.last_epoch == 0 or self.last_epoch % self.step_size != 0:
             return self.get_current_batch_size()
-        return int(self.get_current_batch_size() * self.gamma)
+        return rint(self.get_current_batch_size() * self.gamma)
 
 
 class MultiStepBS(BSScheduler):
@@ -430,7 +438,7 @@ class MultiStepBS(BSScheduler):
         """
         if self.last_epoch not in self.milestones:
             return self.get_current_batch_size()
-        return int(self.get_current_batch_size() * self.gamma ** self.milestones[self.last_epoch])
+        return rint(self.get_current_batch_size() * self.gamma ** self.milestones[self.last_epoch])
 
 
 class ConstantBS(BSScheduler):
@@ -492,12 +500,12 @@ class ConstantBS(BSScheduler):
                 self.factor = max_factor
             elif self.factor < min_factor:
                 self.factor = min_factor
-            return int(current_batch_size * self.factor)
+            return rint(current_batch_size * self.factor)
 
         if self.last_epoch != self.milestone:
             return current_batch_size
 
-        return int(current_batch_size * (1.0 / self.factor))
+        return rint(current_batch_size * (1.0 / self.factor))
 
 
 class LinearBS(BSScheduler):
@@ -559,8 +567,8 @@ class LinearBS(BSScheduler):
             return current_batch_size
 
         if self.last_epoch == 0:
-            return int(current_batch_size * self.start_factor)
+            return rint(current_batch_size * self.start_factor)
 
         value_range = self.end_factor - self.start_factor
-        return int(current_batch_size * (
+        return rint(current_batch_size * (
                 1.0 + value_range / (self.milestone * self.start_factor + (self.last_epoch - 1) * value_range)))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "bs_scheduler"
-version = "0.1.1"
+version = "0.1.2"
 requires-python = ">=3.9"
 description = "A PyTorch Dataloader compatible batch size scheduler library."
 readme = "README.md"

--- a/tests/test_ConstantBS.py
+++ b/tests/test_ConstantBS.py
@@ -2,7 +2,7 @@ import unittest
 
 from bs_scheduler import ConstantBS
 from tests.test_utils import create_dataloader, simulate_n_epochs, fashion_mnist, \
-    get_batch_sizes_across_epochs, BSTest, clip, rint
+    get_batch_sizes_across_epochs, BSTest, rint
 
 
 class TestConstantBS(BSTest):

--- a/tests/test_ConstantBS.py
+++ b/tests/test_ConstantBS.py
@@ -1,0 +1,59 @@
+import unittest
+
+from bs_scheduler import ConstantBS
+from tests.test_utils import create_dataloader, simulate_n_epochs, fashion_mnist, \
+    get_batch_sizes_across_epochs, BSTest, clip
+
+
+class TestConstantBS(BSTest):
+    def setUp(self):
+        self.base_batch_size = 64
+        self.dataset = fashion_mnist()
+        # TODO: Test multiple dataloaders: dataloader with workers, dataloaders with samplers, with drop last and
+        #  without drop last and so on.
+
+    @staticmethod
+    def compute_expected_batch_sizes(epochs, base_batch_size, step_size, gamma, min_batch_size, max_batch_size):
+        return None
+        expected_batch_sizes = [base_batch_size]  # Base batch size is added as a boundary condition.
+        for epoch in range(epochs):
+            last_batch_size = expected_batch_sizes[-1]
+            if epoch == 0 or epoch % step_size != 0:
+                expected_batch_sizes.append(last_batch_size)
+            else:
+                expected_batch_sizes.append(clip(int(last_batch_size * gamma), min_batch_size, max_batch_size))
+        expected_batch_sizes.pop(0)  # Removing base batch size.
+        return expected_batch_sizes
+
+    def test_dataloader_lengths(self):
+        dataloader = create_dataloader(self.dataset, batch_size=self.base_batch_size)
+        factor = 5.0
+        milestone = 5
+        scheduler = ConstantBS(dataloader, factor=factor, milestone=milestone)
+        n_epochs = 10
+
+        epoch_lengths = simulate_n_epochs(dataloader, scheduler, n_epochs)
+        expected_batch_sizes = [int(self.base_batch_size * factor)] * 5 + [self.base_batch_size] * 5
+        expected_lengths = self.compute_epoch_lengths(expected_batch_sizes, len(self.dataset), drop_last=False)
+
+        self.assertEqual(epoch_lengths, expected_lengths)
+
+    def test_dataloader_batch_size(self):
+        dataloader = create_dataloader(self.dataset, batch_size=self.base_batch_size)
+        factor = 5.0
+        milestone = 5
+        scheduler = ConstantBS(dataloader, factor=factor, milestone=milestone, max_batch_size=100, verbose=False)
+        n_epochs = 15
+        self.assertAlmostEqual(scheduler.factor, scheduler.max_batch_size / self.base_batch_size)
+
+        batch_sizes = get_batch_sizes_across_epochs(dataloader, scheduler, n_epochs)
+        expected_batch_sizes = [int(self.base_batch_size * scheduler.factor)] * 5 + [self.base_batch_size] * 10
+
+        self.assertEqual(batch_sizes, expected_batch_sizes)
+
+
+if __name__ == "__main__":
+    from multiprocessing import freeze_support
+
+    freeze_support()
+    unittest.main()

--- a/tests/test_ConstantBS.py
+++ b/tests/test_ConstantBS.py
@@ -12,19 +12,6 @@ class TestConstantBS(BSTest):
         # TODO: Test multiple dataloaders: dataloader with workers, dataloaders with samplers, with drop last and
         #  without drop last and so on.
 
-    @staticmethod
-    def compute_expected_batch_sizes(epochs, base_batch_size, step_size, gamma, min_batch_size, max_batch_size):
-        return None
-        expected_batch_sizes = [base_batch_size]  # Base batch size is added as a boundary condition.
-        for epoch in range(epochs):
-            last_batch_size = expected_batch_sizes[-1]
-            if epoch == 0 or epoch % step_size != 0:
-                expected_batch_sizes.append(last_batch_size)
-            else:
-                expected_batch_sizes.append(clip(int(last_batch_size * gamma), min_batch_size, max_batch_size))
-        expected_batch_sizes.pop(0)  # Removing base batch size.
-        return expected_batch_sizes
-
     def test_dataloader_lengths(self):
         dataloader = create_dataloader(self.dataset, batch_size=self.base_batch_size)
         factor = 5.0

--- a/tests/test_ConstantBS.py
+++ b/tests/test_ConstantBS.py
@@ -2,7 +2,7 @@ import unittest
 
 from bs_scheduler import ConstantBS
 from tests.test_utils import create_dataloader, simulate_n_epochs, fashion_mnist, \
-    get_batch_sizes_across_epochs, BSTest, clip
+    get_batch_sizes_across_epochs, BSTest, clip, rint
 
 
 class TestConstantBS(BSTest):
@@ -20,7 +20,7 @@ class TestConstantBS(BSTest):
         n_epochs = 10
 
         epoch_lengths = simulate_n_epochs(dataloader, scheduler, n_epochs)
-        expected_batch_sizes = [int(self.base_batch_size * factor)] * 5 + [self.base_batch_size] * 5
+        expected_batch_sizes = [rint(self.base_batch_size * factor)] * 5 + [self.base_batch_size] * 5
         expected_lengths = self.compute_epoch_lengths(expected_batch_sizes, len(self.dataset), drop_last=False)
 
         self.assertEqual(epoch_lengths, expected_lengths)
@@ -34,7 +34,7 @@ class TestConstantBS(BSTest):
         self.assertAlmostEqual(scheduler.factor, scheduler.max_batch_size / self.base_batch_size)
 
         batch_sizes = get_batch_sizes_across_epochs(dataloader, scheduler, n_epochs)
-        expected_batch_sizes = [int(self.base_batch_size * scheduler.factor)] * 5 + [self.base_batch_size] * 10
+        expected_batch_sizes = [rint(self.base_batch_size * scheduler.factor)] * 5 + [self.base_batch_size] * 10
 
         self.assertEqual(batch_sizes, expected_batch_sizes)
 

--- a/tests/test_ExponentialBS.py
+++ b/tests/test_ExponentialBS.py
@@ -1,0 +1,45 @@
+import unittest
+
+import numpy as np
+import torch
+
+from bs_scheduler import ExponentialBS
+from tests.test_utils import create_dataloader, simulate_n_epochs, fashion_mnist, \
+    get_batch_sizes_across_epochs, BSTest, clip, rint
+
+
+class TestExponentialBS(BSTest):
+    def setUp(self):
+        self.base_batch_size = 64
+        self.dataset = fashion_mnist()
+        # TODO: Test multiple dataloaders: dataloader with workers, dataloaders with samplers, with drop last and
+        #  without drop last and so on.
+
+    def test_dataloader_lengths(self):
+        dataloader = create_dataloader(self.dataset, batch_size=self.base_batch_size)
+
+        scheduler = ExponentialBS(dataloader, gamma=1.1)
+        n_epochs = 5
+
+        epoch_lengths = simulate_n_epochs(dataloader, scheduler, n_epochs)
+        expected_batch_sizes = [64, 70, 77, 85, 94]
+        expected_lengths = self.compute_epoch_lengths(expected_batch_sizes, len(self.dataset), drop_last=False)
+        self.assertEqual(epoch_lengths, expected_lengths)
+
+    def test_dataloader_batch_size(self):
+        base_batch_size = 10
+        dataloader = create_dataloader(self.dataset, batch_size=base_batch_size)
+        scheduler = ExponentialBS(dataloader, gamma=2, max_batch_size=100, verbose=False)
+        n_epochs = 10
+
+        batch_sizes = get_batch_sizes_across_epochs(dataloader, scheduler, n_epochs)
+        expected_batch_sizes = [10, 20, 40, 80] + [100] * 6
+
+        self.assertEqual(batch_sizes, expected_batch_sizes)
+
+
+if __name__ == "__main__":
+    from multiprocessing import freeze_support
+
+    freeze_support()
+    unittest.main()

--- a/tests/test_ExponentialBS.py
+++ b/tests/test_ExponentialBS.py
@@ -1,11 +1,8 @@
 import unittest
 
-import numpy as np
-import torch
-
 from bs_scheduler import ExponentialBS
 from tests.test_utils import create_dataloader, simulate_n_epochs, fashion_mnist, \
-    get_batch_sizes_across_epochs, BSTest, clip, rint
+    get_batch_sizes_across_epochs, BSTest
 
 
 class TestExponentialBS(BSTest):

--- a/tests/test_LambdaBS.py
+++ b/tests/test_LambdaBS.py
@@ -19,11 +19,15 @@ class TestLambdaBS(BSTest):
     def test_sanity(self):
         dataloader = create_dataloader(self.dataset, batch_size=self.base_batch_size)
         real, inferred = iterate(dataloader)
-        self.assert_real_eq_inferred(real, inferred)
+        self.assertEqual(real, inferred, "Dataloader __len__ does not return the real length. The real length should "
+                                         "always be equal to the inferred length except for Iterable Datasets for "
+                                         "which the __len__ could be inaccurate.")
 
         dataloader.batch_sampler.batch_size = 526
         real, inferred = iterate(dataloader)
-        self.assert_real_eq_inferred(real, inferred)
+        self.assertEqual(real, inferred, "Dataloader __len__ does not return the real length. The real length should "
+                                         "always be equal to the inferred length except for Iterable Datasets for "
+                                         "which the __len__ could be inaccurate.")
 
     def test_dataloader_lengths(self):
         dataloader = create_dataloader(self.dataset, batch_size=self.base_batch_size)
@@ -37,7 +41,7 @@ class TestLambdaBS(BSTest):
                                                                  scheduler.min_batch_size, scheduler.max_batch_size)
         expected_lengths = self.compute_epoch_lengths(expected_batch_sizes, len(self.dataset), drop_last=False)
 
-        self.assert_real_eq_expected(epoch_lengths, expected_lengths)
+        self.assertEqual(epoch_lengths, expected_lengths)
 
     def test_dataloader_batch_size(self):
         dataloader = create_dataloader(self.dataset, batch_size=self.base_batch_size)
@@ -48,7 +52,7 @@ class TestLambdaBS(BSTest):
         batch_sizes = get_batch_sizes_across_epochs(dataloader, scheduler, n_epochs)
         expected_batch_sizes = self.compute_expected_batch_sizes(n_epochs, self.base_batch_size, fn,
                                                                  scheduler.min_batch_size, scheduler.max_batch_size)
-        self.assert_real_eq_expected(batch_sizes, expected_batch_sizes)
+        self.assertEqual(batch_sizes, expected_batch_sizes)
 
 
 if __name__ == "__main__":

--- a/tests/test_LambdaBS.py
+++ b/tests/test_LambdaBS.py
@@ -2,7 +2,7 @@ import unittest
 
 from bs_scheduler import LambdaBS
 from tests.test_utils import create_dataloader, iterate, simulate_n_epochs, fashion_mnist, \
-    get_batch_sizes_across_epochs, BSTest, clip
+    get_batch_sizes_across_epochs, BSTest, clip, rint
 
 
 class TestLambdaBS(BSTest):
@@ -14,7 +14,7 @@ class TestLambdaBS(BSTest):
 
     @staticmethod
     def compute_expected_batch_sizes(epochs, base_batch_size, fn, min_batch_size, max_batch_size):
-        return [clip(int(base_batch_size * fn(epoch)), min_batch_size, max_batch_size) for epoch in range(epochs)]
+        return [clip(rint(base_batch_size * fn(epoch)), min_batch_size, max_batch_size) for epoch in range(epochs)]
 
     def test_sanity(self):
         dataloader = create_dataloader(self.dataset, batch_size=self.base_batch_size)

--- a/tests/test_LinearBS.py
+++ b/tests/test_LinearBS.py
@@ -5,7 +5,7 @@ import torch
 
 from bs_scheduler import LinearBS
 from tests.test_utils import create_dataloader, simulate_n_epochs, fashion_mnist, \
-    get_batch_sizes_across_epochs, BSTest, clip
+    get_batch_sizes_across_epochs, BSTest, clip, rint
 
 
 class TestLinearBS(BSTest):
@@ -25,8 +25,8 @@ class TestLinearBS(BSTest):
             if epoch > milestone:
                 expected_batch_sizes.append(last_batch_size)
             else:
-                last_batch_size *= factors[epoch]
-                last_batch_size = clip(int(last_batch_size), min_batch_size, max_batch_size)
+                last_batch_size *= factors[epoch].item()
+                last_batch_size = clip(rint(last_batch_size), min_batch_size, max_batch_size)
                 expected_batch_sizes.append(last_batch_size)
         expected_batch_sizes.pop(0)  # Removing base batch size.
         return expected_batch_sizes

--- a/tests/test_LinearBS.py
+++ b/tests/test_LinearBS.py
@@ -1,6 +1,5 @@
 import unittest
 
-import numpy as np
 import torch
 
 from bs_scheduler import LinearBS

--- a/tests/test_LinearBS.py
+++ b/tests/test_LinearBS.py
@@ -1,0 +1,66 @@
+import unittest
+
+import numpy as np
+import torch
+
+from bs_scheduler import LinearBS
+from tests.test_utils import create_dataloader, simulate_n_epochs, fashion_mnist, \
+    get_batch_sizes_across_epochs, BSTest, clip
+
+
+class TestLinearBS(BSTest):
+    def setUp(self):
+        self.base_batch_size = 64
+        self.dataset = fashion_mnist()
+        # TODO: Test multiple dataloaders: dataloader with workers, dataloaders with samplers, with drop last and
+        #  without drop last and so on.
+
+    @staticmethod
+    def compute_expected_batch_sizes(epochs, base_batch_size, start_factor, end_factor, milestone, min_batch_size, max_batch_size):
+        expected_batch_sizes = [base_batch_size]  # Base batch size is added as a boundary condition.
+        factors = torch.linspace(start_factor, end_factor, milestone + 1)
+        factors[1:] = factors[1:] / factors[:-1]
+        for epoch in range(epochs):
+            last_batch_size = expected_batch_sizes[-1]
+            if epoch > milestone:
+                expected_batch_sizes.append(last_batch_size)
+            else:
+                last_batch_size *= factors[epoch]
+                last_batch_size = clip(int(last_batch_size), min_batch_size, max_batch_size)
+                expected_batch_sizes.append(last_batch_size)
+        expected_batch_sizes.pop(0)  # Removing base batch size.
+        return expected_batch_sizes
+
+    def test_dataloader_lengths(self):
+        dataloader = create_dataloader(self.dataset, batch_size=self.base_batch_size)
+        start_factor = 12.0
+        end_factor = 3.0
+        milestone = 5
+        scheduler = LinearBS(dataloader, verbose=False, start_factor=start_factor, end_factor=end_factor, milestone=milestone)
+        n_epochs = 10
+
+        epoch_lengths = simulate_n_epochs(dataloader, scheduler, n_epochs)
+        expected_batch_sizes = self.compute_expected_batch_sizes(n_epochs, self.base_batch_size, start_factor=start_factor, end_factor=end_factor, milestone=milestone, min_batch_size=scheduler.min_batch_size, max_batch_size=scheduler.max_batch_size)
+        expected_lengths = self.compute_epoch_lengths(expected_batch_sizes, len(self.dataset), drop_last=False)
+        self.assertEqual(epoch_lengths, expected_lengths)
+
+    def test_dataloader_batch_size(self):
+        base_batch_size = 10
+        dataloader = create_dataloader(self.dataset, batch_size=base_batch_size)
+        start_factor = 6.0
+        end_factor = 1.0
+        milestone = 5
+        scheduler = LinearBS(dataloader, start_factor=start_factor, end_factor=end_factor, milestone=milestone, max_batch_size=100, verbose=False)
+        n_epochs = 15
+
+        batch_sizes = get_batch_sizes_across_epochs(dataloader, scheduler, n_epochs)
+        expected_batch_sizes = [60, 50, 40, 30, 20] + [10] * 10
+
+        self.assertEqual(batch_sizes, expected_batch_sizes)
+
+
+if __name__ == "__main__":
+    from multiprocessing import freeze_support
+
+    freeze_support()
+    unittest.main()

--- a/tests/test_MultiStepBS.py
+++ b/tests/test_MultiStepBS.py
@@ -1,11 +1,11 @@
 import unittest
 
-from bs_scheduler import StepBS
+from bs_scheduler import MultiStepBS
 from tests.test_utils import create_dataloader, simulate_n_epochs, fashion_mnist, \
     get_batch_sizes_across_epochs, BSTest, clip
 
 
-class TestStepBS(BSTest):
+class TestMultiStepBS(BSTest):
     def setUp(self):
         self.base_batch_size = 64
         self.dataset = fashion_mnist()
@@ -13,26 +13,25 @@ class TestStepBS(BSTest):
         #  without drop last and so on.
 
     @staticmethod
-    def compute_expected_batch_sizes(epochs, base_batch_size, step_size, gamma, min_batch_size, max_batch_size):
+    def compute_expected_batch_sizes(epochs, base_batch_size, milestones, gamma, min_batch_size, max_batch_size):
         expected_batch_sizes = [base_batch_size]  # Base batch size is added as a boundary condition.
         for epoch in range(epochs):
             last_batch_size = expected_batch_sizes[-1]
-            if epoch == 0 or epoch % step_size != 0:
-                expected_batch_sizes.append(last_batch_size)
-            else:
-                expected_batch_sizes.append(clip(int(last_batch_size * gamma), min_batch_size, max_batch_size))
-        expected_batch_sizes.pop(0)  # Removing base batch size.
+            for _ in range(milestones.count(epoch)):
+                last_batch_size *= gamma
+            expected_batch_sizes.append(clip(int(last_batch_size), min_batch_size, max_batch_size))
+        expected_batch_sizes.pop(0)  # Removing base batch size
         return expected_batch_sizes
 
     def test_dataloader_lengths(self):
         dataloader = create_dataloader(self.dataset, batch_size=self.base_batch_size)
-        step_size = 50
+        milestones = [10, 50, 70, 70, 80]
         gamma = 1.1
-        scheduler = StepBS(dataloader, step_size=step_size, gamma=gamma)
+        scheduler = MultiStepBS(dataloader, milestones=milestones, gamma=gamma)
         n_epochs = 300
 
         epoch_lengths = simulate_n_epochs(dataloader, scheduler, n_epochs)
-        expected_batch_sizes = self.compute_expected_batch_sizes(n_epochs, self.base_batch_size, step_size, gamma,
+        expected_batch_sizes = self.compute_expected_batch_sizes(n_epochs, self.base_batch_size, milestones, gamma,
                                                                  scheduler.min_batch_size, scheduler.max_batch_size)
         expected_lengths = self.compute_epoch_lengths(expected_batch_sizes, len(self.dataset), drop_last=False)
 
@@ -40,13 +39,13 @@ class TestStepBS(BSTest):
 
     def test_dataloader_batch_size(self):
         dataloader = create_dataloader(self.dataset, batch_size=self.base_batch_size)
-        step_size = 5
+        milestones = [5, 10, 10, 12]
         gamma = 3.0
-        scheduler = StepBS(dataloader, step_size=step_size, gamma=gamma, max_batch_size=5000, verbose=False)
+        scheduler = MultiStepBS(dataloader, milestones=milestones, gamma=gamma, max_batch_size=5000, verbose=False)
         n_epochs = 15
 
         batch_sizes = get_batch_sizes_across_epochs(dataloader, scheduler, n_epochs)
-        expected_batch_sizes = self.compute_expected_batch_sizes(n_epochs, self.base_batch_size, step_size, gamma,
+        expected_batch_sizes = self.compute_expected_batch_sizes(n_epochs, self.base_batch_size, milestones, gamma,
                                                                  scheduler.min_batch_size, scheduler.max_batch_size)
 
         self.assertEqual(batch_sizes, expected_batch_sizes)

--- a/tests/test_MultiStepBS.py
+++ b/tests/test_MultiStepBS.py
@@ -2,7 +2,7 @@ import unittest
 
 from bs_scheduler import MultiStepBS
 from tests.test_utils import create_dataloader, simulate_n_epochs, fashion_mnist, \
-    get_batch_sizes_across_epochs, BSTest, clip
+    get_batch_sizes_across_epochs, BSTest, clip, rint
 
 
 class TestMultiStepBS(BSTest):
@@ -19,7 +19,7 @@ class TestMultiStepBS(BSTest):
             last_batch_size = expected_batch_sizes[-1]
             for _ in range(milestones.count(epoch)):
                 last_batch_size *= gamma
-            expected_batch_sizes.append(clip(int(last_batch_size), min_batch_size, max_batch_size))
+            expected_batch_sizes.append(clip(rint(last_batch_size), min_batch_size, max_batch_size))
         expected_batch_sizes.pop(0)  # Removing base batch size
         return expected_batch_sizes
 

--- a/tests/test_MultiStepBS.py
+++ b/tests/test_MultiStepBS.py
@@ -25,7 +25,7 @@ class TestMultiStepBS(BSTest):
 
     def test_dataloader_lengths(self):
         dataloader = create_dataloader(self.dataset, batch_size=self.base_batch_size)
-        milestones = [10, 50, 70, 70, 80]
+        milestones = [70, 70, 80, 10, 50]
         gamma = 1.1
         scheduler = MultiStepBS(dataloader, milestones=milestones, gamma=gamma)
         n_epochs = 300

--- a/tests/test_MultiplicativeBS.py
+++ b/tests/test_MultiplicativeBS.py
@@ -2,7 +2,7 @@ import unittest
 
 from bs_scheduler import MultiplicativeBS
 from tests.test_utils import create_dataloader, simulate_n_epochs, fashion_mnist, \
-    get_batch_sizes_across_epochs, BSTest, clip
+    get_batch_sizes_across_epochs, BSTest, clip, rint
 
 
 class TestMultiplicativeBS(BSTest):
@@ -16,7 +16,7 @@ class TestMultiplicativeBS(BSTest):
     def compute_expected_batch_sizes(epochs, base_batch_size, fn, min_batch_size, max_batch_size):
         expected_batch_sizes = [base_batch_size]  # Base batch size is added as a boundary condition.
         for epoch in range(epochs):
-            batch_size = int(expected_batch_sizes[-1] * fn(epoch))
+            batch_size = rint(expected_batch_sizes[-1] * fn(epoch))
             batch_size = clip(batch_size, min_batch_size, max_batch_size)
             expected_batch_sizes.append(batch_size)
         expected_batch_sizes.pop(0)  # Removing base batch size.

--- a/tests/test_SequentialBS.py
+++ b/tests/test_SequentialBS.py
@@ -1,0 +1,103 @@
+import os
+import unittest
+
+from bs_scheduler import SequentialBS, ConstantBS, ExponentialBS, LinearBS, BatchSizeManager
+from tests.test_utils import create_dataloader, simulate_n_epochs, fashion_mnist, \
+    get_batch_sizes_across_epochs, BSTest
+
+
+class TestSequentialBS(BSTest):
+    def setUp(self):
+        self.base_batch_size = 64
+        self.dataset = fashion_mnist()
+        # TODO: Test multiple dataloaders: dataloader with workers, dataloaders with samplers, with drop last and
+        #  without drop last and so on.
+        # TODO: Test more combinations of batch size schedulers.
+        # TODO: Check that SequentialBS throws errors when it should.
+
+    def test_dataloader_lengths(self):
+        # TODO: torch.optim.lr_scheduler.SequentialLR might be wrong: test it.
+        base_batch_size = 10
+        dataloader = create_dataloader(self.dataset, batch_size=base_batch_size)
+        scheduler1 = ConstantBS(dataloader, factor=10, milestone=4)
+        scheduler2 = ExponentialBS(dataloader, gamma=1.1)
+        scheduler = SequentialBS(dataloader, schedulers=[scheduler1, scheduler2], milestones=[5])
+        n_epochs = 10
+
+        epoch_lengths = simulate_n_epochs(dataloader, scheduler, n_epochs)
+        expected_batch_sizes = [100] * 4 + [10, 11, 12, 13, 14, 15]
+        expected_lengths = self.compute_epoch_lengths(expected_batch_sizes, len(self.dataset), drop_last=False)
+        self.assertEqual(epoch_lengths, expected_lengths)
+
+    def test_dataloader_batch_size(self):
+        base_batch_size = 10
+        dataloader = create_dataloader(self.dataset, batch_size=base_batch_size)
+        scheduler1 = ConstantBS(dataloader, factor=10, milestone=4, max_batch_size=100)
+        scheduler2 = ExponentialBS(dataloader, gamma=2, max_batch_size=100, verbose=False)
+        scheduler = SequentialBS(dataloader, schedulers=[scheduler1, scheduler2], milestones=[5], max_batch_size=100)
+        n_epochs = 10
+
+        batch_sizes = get_batch_sizes_across_epochs(dataloader, scheduler, n_epochs)
+        expected_batch_sizes = [100] * 4 + [10, 20, 40, 80, 100, 100]
+
+        self.assertEqual(batch_sizes, expected_batch_sizes)
+
+    def test_preconditions(self):
+        dataloader = create_dataloader(self.dataset, batch_size=self.base_batch_size)
+        scheduler1 = ConstantBS(dataloader, factor=10, milestone=4, max_batch_size=100)
+        scheduler2 = ExponentialBS(dataloader, gamma=2, max_batch_size=100, verbose=False)
+        scheduler3 = LinearBS(dataloader, max_batch_size=100, verbose=False)
+        if len(os.getenv('PYTHONOPTIMIZE', '')) == 0:
+            with self.assertRaises(AssertionError):
+                SequentialBS(dataloader, schedulers=scheduler1, milestones=[5], max_batch_size=100)
+            with self.assertRaises(AssertionError):
+                SequentialBS(dataloader, schedulers=[scheduler1], milestones=[5], max_batch_size=100)
+            with self.assertRaises(AssertionError):
+                SequentialBS(dataloader, schedulers=[scheduler1, scheduler2], milestones=5, max_batch_size=100)
+            with self.assertRaises(AssertionError):
+                SequentialBS(dataloader, schedulers=[scheduler1, scheduler2], milestones=[], max_batch_size=100)
+            with self.assertRaises(AssertionError):
+                SequentialBS(dataloader, schedulers=[scheduler1, scheduler2], milestones=[0], max_batch_size=100)
+            with self.assertRaises(AssertionError):
+                SequentialBS(dataloader, schedulers=[scheduler1, scheduler2, scheduler3], milestones=[10, 5],
+                             max_batch_size=100)
+            with self.assertRaises(ValueError):
+                SequentialBS(dataloader, schedulers=[scheduler1, scheduler2, scheduler3], milestones=[10],
+                             max_batch_size=100)
+
+        SequentialBS(dataloader, schedulers=[scheduler1, scheduler2, scheduler3], milestones=[5, 10],
+                     max_batch_size=100)
+        with self.assertRaises(ValueError):
+            other_dataloader = create_dataloader(self.dataset, batch_size=self.base_batch_size)
+            other_scheduler = ConstantBS(other_dataloader, factor=10, milestone=4, max_batch_size=100)
+            SequentialBS(dataloader, schedulers=[other_scheduler, scheduler2, scheduler3], milestones=[5, 10],
+                         max_batch_size=100)
+
+        with self.assertRaises(ValueError):
+            class OtherBatchManager(BatchSizeManager):
+                def get_current_batch_size(self) -> int:
+                    return 10
+
+                def set_batch_size(self, new_bs: int):
+                    pass
+
+            other_scheduler = ConstantBS(dataloader, factor=10, milestone=4, max_batch_size=100,
+                                         batch_size_manager=OtherBatchManager())
+            SequentialBS(dataloader, schedulers=[other_scheduler, scheduler2, scheduler3], milestones=[5, 10],
+                         max_batch_size=100)
+
+        with self.assertRaises(ValueError):
+            other_scheduler = ConstantBS(dataloader, factor=10, milestone=4, max_batch_size=555)
+            SequentialBS(dataloader, schedulers=[other_scheduler, scheduler2, scheduler3], milestones=[5, 10],
+                         max_batch_size=100)
+        with self.assertRaises(ValueError):
+            other_scheduler = ConstantBS(dataloader, factor=10, milestone=4, min_batch_size=2)
+            SequentialBS(dataloader, schedulers=[other_scheduler, scheduler2, scheduler3], milestones=[5, 10],
+                         max_batch_size=100)
+
+
+if __name__ == "__main__":
+    from multiprocessing import freeze_support
+
+    freeze_support()
+    unittest.main()

--- a/tests/test_StepBS.py
+++ b/tests/test_StepBS.py
@@ -2,7 +2,7 @@ import unittest
 
 from bs_scheduler import StepBS
 from tests.test_utils import create_dataloader, simulate_n_epochs, fashion_mnist, \
-    get_batch_sizes_across_epochs, BSTest, clip
+    get_batch_sizes_across_epochs, BSTest, clip, rint
 
 
 class TestStepBS(BSTest):
@@ -20,7 +20,7 @@ class TestStepBS(BSTest):
             if epoch == 0 or epoch % step_size != 0:
                 expected_batch_sizes.append(last_batch_size)
             else:
-                expected_batch_sizes.append(clip(int(last_batch_size * gamma), min_batch_size, max_batch_size))
+                expected_batch_sizes.append(clip(rint(last_batch_size * gamma), min_batch_size, max_batch_size))
         expected_batch_sizes.pop(0)  # Removing base batch size.
         return expected_batch_sizes
 

--- a/tests/test_StepBS.py
+++ b/tests/test_StepBS.py
@@ -1,11 +1,11 @@
 import unittest
 
-from bs_scheduler import MultiplicativeBS
+from bs_scheduler import StepBS
 from tests.test_utils import create_dataloader, simulate_n_epochs, fashion_mnist, \
     get_batch_sizes_across_epochs, BSTest, clip
 
 
-class TestMultiplicativeBS(BSTest):
+class TestStepBS(BSTest):
     def setUp(self):
         self.base_batch_size = 64
         self.dataset = fashion_mnist()
@@ -13,23 +13,26 @@ class TestMultiplicativeBS(BSTest):
         #  without drop last and so on.
 
     @staticmethod
-    def compute_expected_batch_sizes(epochs, base_batch_size, fn, min_batch_size, max_batch_size):
+    def compute_expected_batch_sizes(epochs, base_batch_size, step_size, gamma, min_batch_size, max_batch_size):
         expected_batch_sizes = [base_batch_size]  # Base batch size is added as a boundary condition.
         for epoch in range(epochs):
-            batch_size = int(expected_batch_sizes[-1] * fn(epoch))
-            batch_size = clip(batch_size, min_batch_size, max_batch_size)
-            expected_batch_sizes.append(batch_size)
+            last_batch_size = expected_batch_sizes[-1]
+            if epoch == 0 or epoch % step_size != 0:
+                expected_batch_sizes.append(last_batch_size)
+            else:
+                expected_batch_sizes.append(int(last_batch_size * gamma))
         expected_batch_sizes.pop(0)  # Removing base batch size.
         return expected_batch_sizes
 
     def test_dataloader_lengths(self):
         dataloader = create_dataloader(self.dataset, batch_size=self.base_batch_size)
-        fn = lambda epoch: epoch / 100 + 1
-        scheduler = MultiplicativeBS(dataloader, fn)
+        step_size = 50
+        gamma = 1.1
+        scheduler = StepBS(dataloader, step_size=step_size, gamma=gamma)
         n_epochs = 300
 
         epoch_lengths = simulate_n_epochs(dataloader, scheduler, n_epochs)
-        expected_batch_sizes = self.compute_expected_batch_sizes(n_epochs, self.base_batch_size, fn,
+        expected_batch_sizes = self.compute_expected_batch_sizes(n_epochs, self.base_batch_size, step_size, gamma,
                                                                  scheduler.min_batch_size, scheduler.max_batch_size)
         expected_lengths = self.compute_epoch_lengths(expected_batch_sizes, len(self.dataset), drop_last=False)
 
@@ -37,12 +40,13 @@ class TestMultiplicativeBS(BSTest):
 
     def test_dataloader_batch_size(self):
         dataloader = create_dataloader(self.dataset, batch_size=self.base_batch_size)
-        fn = lambda epoch: epoch / 100 + 2
-        scheduler = MultiplicativeBS(dataloader, fn, max_batch_size=5000, verbose=False)
+        step_size = 5
+        gamma = 3.0
+        scheduler = StepBS(dataloader, step_size=step_size, gamma=gamma, max_batch_size=5000, verbose=False)
         n_epochs = 15
 
         batch_sizes = get_batch_sizes_across_epochs(dataloader, scheduler, n_epochs)
-        expected_batch_sizes = self.compute_expected_batch_sizes(n_epochs, self.base_batch_size, fn,
+        expected_batch_sizes = self.compute_expected_batch_sizes(n_epochs, self.base_batch_size, step_size, gamma,
                                                                  scheduler.min_batch_size, scheduler.max_batch_size)
 
         self.assertEqual(batch_sizes, expected_batch_sizes)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -65,13 +65,6 @@ def clip(x, min_x, max_x):
 
 
 class BSTest(unittest.TestCase):
-    def assert_real_eq_inferred(self, real, inferred):
-        self.assertEqual(real, inferred, "Dataloader __len__ does not return the real length. The real length should "
-                                         "always be equal to the inferred length except for Iterable Datasets for "
-                                         "which the __len__ could be inaccurate.")
-
-    def assert_real_eq_expected(self, real, expected):
-        self.assertEqual(real, expected, f"Expected {expected}, got {real}")
 
     @staticmethod
     def compute_epoch_lengths(batch_sizes, dataset_len, drop_last):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -60,6 +60,12 @@ def get_batch_sizes_across_epochs(dataloader, scheduler, epochs):
     return batch_sizes
 
 
+def rint(x: float) -> int:
+    """ Rounds to the nearest int and returns the value as int.
+    """
+    return int(round(x))
+
+
 def clip(x, min_x, max_x):
     return min(max(x, min_x), max_x)
 


### PR DESCRIPTION
* Changed batch size casting strategy from int casting to rounding first and then casting to int. This would improve batch size stability and expected results when using batch size schedulers. Also changed previous tests to account for rounding then casting to int.
* Added assertions to validate the parameter value when initializing batch scheduler, in addition to the previous exceptions raised for sensitive parameters. 
* Moved the `base_bs` member variable from the batch scheduler to dataloader, to account for multiple schedulers for the same dataloader. 