### PR TITLE
API breaking changes and new schedulers.

### DIFF
--- a/bs_scheduler/__init__.py
+++ b/bs_scheduler/__init__.py
@@ -1,10 +1,12 @@
 from .batch_size_schedulers import LambdaBS, MultiplicativeBS, StepBS, MultiStepBS, ConstantBS, LinearBS, ExponentialBS, \
-    SequentialBS, PolynomialBS, CosineAnnealingBS, ChainedBSScheduler, BSScheduler, BatchSizeManager
+    SequentialBS, PolynomialBS, CosineAnnealingBS, ChainedBSScheduler, IncreaseBSOnPlateau, BSScheduler, \
+    BatchSizeManager
 
 # We do not export DefaultBatchSizeManager and CustomBatchSizeManager because they are not needed. Users with custom
 # setups can create their own batch size managers.
 
 __all__ = ['LambdaBS', 'MultiplicativeBS', 'StepBS', 'MultiStepBS', 'ConstantBS', 'LinearBS', 'ExponentialBS',
-           'SequentialBS', 'PolynomialBS', 'CosineAnnealingBS', 'ChainedBSScheduler', 'BSScheduler', 'BatchSizeManager']
+           'SequentialBS', 'PolynomialBS', 'CosineAnnealingBS', 'ChainedBSScheduler', 'IncreaseBSOnPlateau',
+           'BSScheduler', 'BatchSizeManager']
 
 del batch_size_schedulers

--- a/bs_scheduler/__init__.py
+++ b/bs_scheduler/__init__.py
@@ -1,10 +1,10 @@
 from .batch_size_schedulers import LambdaBS, MultiplicativeBS, StepBS, MultiStepBS, ConstantBS, LinearBS, ExponentialBS, \
-    SequentialBS, PolynomialBS, CosineAnnealingBS, BSScheduler, BatchSizeManager
+    SequentialBS, PolynomialBS, CosineAnnealingBS, ChainedBSScheduler, BSScheduler, BatchSizeManager
 
 # We do not export DefaultBatchSizeManager and CustomBatchSizeManager because they are not needed. Users with custom
 # setups can create their own batch size managers.
 
 __all__ = ['LambdaBS', 'MultiplicativeBS', 'StepBS', 'MultiStepBS', 'ConstantBS', 'LinearBS', 'ExponentialBS',
-           'SequentialBS', 'PolynomialBS', 'CosineAnnealingBS', 'BSScheduler', 'BatchSizeManager']
+           'SequentialBS', 'PolynomialBS', 'CosineAnnealingBS', 'ChainedBSScheduler', 'BSScheduler', 'BatchSizeManager']
 
 del batch_size_schedulers

--- a/bs_scheduler/batch_size_schedulers.py
+++ b/bs_scheduler/batch_size_schedulers.py
@@ -466,12 +466,21 @@ class MultiStepBS(BSScheduler):
         self.gamma: float = gamma
         super().__init__(dataloader, batch_size_manager, max_batch_size, min_batch_size, verbose)
 
+    @property
+    def finished(self) -> bool:
+        """ Returns True if the scheduler has already finished its job or has exceeded the minimum or maximum batch
+        size. Otherwise, returns False.
+        """
+        if not self._finished:
+            # Should we cache max(self.milestones)?
+            self._finished = self.last_epoch > max(self.milestones)
+        return self._finished
+
     def get_new_bs(self) -> int:
         """ Returns the next batch size as an :class:`int`. It returns the current batch size times gamma each epoch a
         milestone is reached, otherwise it returns the current batch size. Beware that in the event of multiple
         milestones with the same value, the current batch size is multiplied with gamma multiple times.
         """
-        # TODO: Set finished if max milestone was reached.
         if self.last_epoch not in self.milestones:
             return self.batch_size
         return rint(self.batch_size * self.gamma ** self.milestones[self.last_epoch])

--- a/bs_scheduler/batch_size_schedulers.py
+++ b/bs_scheduler/batch_size_schedulers.py
@@ -257,8 +257,8 @@ class LambdaBS(BSScheduler):
         bs_lambda (Union[Callable[[int], float], Callable[[int, ...], float]]): A function which computes a
             multiplicative factor given an integer parameter epoch. The function may accept an additional argument,
             if a keyword argument named `bs_lambda` is passed to the step() function. However, the function must 
-            have a default value for the additional parameter as it is called once only with the epoch parameter during 
-            initialization.
+            have a default value for the additional parameter in order to be able to be used both when passing and not
+            passing the `bs_lambda` keyword argumet to the step() function.
         batch_size_manager (Union[BatchSizeManager, None]): If not None, a custom class which manages the batch size,
             which provides a getter and setter for the batch size. Default: None.
         max_batch_size (Union[int, None]): Upper limit for the batch size so that a batch of size max_batch_size fits
@@ -333,8 +333,8 @@ class MultiplicativeBS(BSScheduler):
         bs_lambda (Union[Callable[[int], float], Callable[[int, ...], float]]): A function which computes a
             multiplicative factor given an integer parameter epoch. The function may accept an additional argument,
             if a keyword argument named `bs_lambda` is passed to the step() function. However, the function must 
-            have a default value for the additional parameter as it is called once only with the epoch parameter during 
-            initialization.
+            have a default value for the additional parameter in order to be able to be used both when passing and not
+            passing the `bs_lambda` keyword argumet to the step() function.
         batch_size_manager (Union[BatchSizeManager, None]): If not None, a custom class which manages the batch size,
             which provides a getter and setter for the batch size. Default: None.
         max_batch_size (Union[int, None]): Upper limit for the batch size so that a batch of size max_batch_size fits

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "bs_scheduler"
-version = "0.1.3"
+version = "0.2.0"
 requires-python = ">=3.9"
 description = "A PyTorch Dataloader compatible batch size scheduler library."
 readme = "README.md"
@@ -12,8 +12,7 @@ maintainers = [
     { name = "George Stoica", email = "george.stoica@senticlab.com"},
 ]
 classifiers = [
-    "Development Status :: 3 - Alpha",
-#    "Development Status :: 4 - Beta",
+    "Development Status :: 4 - Beta",
 #    "Development Status :: 5 - Production/Stable",
     "Intended Audience :: Developers",
     "Intended Audience :: Science/Research",

--- a/tests/test_ChainedBSScheduler.py
+++ b/tests/test_ChainedBSScheduler.py
@@ -1,0 +1,48 @@
+import unittest
+
+from bs_scheduler import ChainedBSScheduler, ConstantBS, ExponentialBS
+from tests.test_utils import create_dataloader, simulate_n_epochs, fashion_mnist, \
+    get_batch_sizes_across_epochs, BSTest, rint
+
+
+class TestChainedBSScheduler(BSTest):
+    def setUp(self):
+        self.base_batch_size = 64
+        self.dataset = fashion_mnist()
+        # TODO: Test multiple dataloaders: dataloader with workers, dataloaders with samplers, with drop last and
+        #  without drop last and so on.
+        # TODO: Test more combinations of batch size schedulers.
+        # TODO: Check that create_dataloader throws errors when it should.
+
+    def test_dataloader_lengths(self):
+        base_batch_size = 10
+        dataloader = create_dataloader(self.dataset, batch_size=base_batch_size)
+        scheduler1 = ConstantBS(dataloader, factor=10, milestone=4)
+        scheduler2 = ExponentialBS(dataloader, gamma=1.1)
+        scheduler = ChainedBSScheduler([scheduler1, scheduler2])
+        n_epochs = 10
+
+        epoch_lengths = simulate_n_epochs(dataloader, scheduler, n_epochs)
+        expected_batch_sizes = [100, 110, 121, 133, 14, 15, 16, 18, 20, 22]
+        expected_lengths = self.compute_epoch_lengths(expected_batch_sizes, len(self.dataset), drop_last=False)
+        self.assertEqual(epoch_lengths, expected_lengths)
+
+    def test_dataloader_batch_size(self):
+        base_batch_size = 10
+        dataloader = create_dataloader(self.dataset, batch_size=base_batch_size)
+        scheduler1 = ConstantBS(dataloader, factor=10, milestone=4)
+        scheduler2 = ExponentialBS(dataloader, gamma=1.1)
+        scheduler = ChainedBSScheduler([scheduler1, scheduler2])
+        n_epochs = 10
+
+        batch_sizes = get_batch_sizes_across_epochs(dataloader, scheduler, n_epochs)
+        expected_batch_sizes = [100, 110, 121, 133, 14, 15, 16, 18, 20, 22]
+
+        self.assertEqual(batch_sizes, expected_batch_sizes)
+
+
+if __name__ == "__main__":
+    from multiprocessing import freeze_support
+
+    freeze_support()
+    unittest.main()

--- a/tests/test_ChainedBSScheduler.py
+++ b/tests/test_ChainedBSScheduler.py
@@ -2,7 +2,7 @@ import unittest
 
 from bs_scheduler import ChainedBSScheduler, ConstantBS, ExponentialBS
 from tests.test_utils import create_dataloader, simulate_n_epochs, fashion_mnist, \
-    get_batch_sizes_across_epochs, BSTest, rint
+    get_batch_sizes_across_epochs, BSTest
 
 
 class TestChainedBSScheduler(BSTest):

--- a/tests/test_IncreaseBSOnPlateau.py
+++ b/tests/test_IncreaseBSOnPlateau.py
@@ -1,0 +1,58 @@
+import unittest
+
+from bs_scheduler import IncreaseBSOnPlateau
+from tests.test_utils import create_dataloader, simulate_n_epochs, fashion_mnist, \
+    BSTest
+
+
+class TestIncreaseBSOnPlateau(BSTest):
+    def setUp(self):
+        self.base_batch_size = 64
+        self.dataset = fashion_mnist()
+        # TODO: Test multiple dataloaders: dataloader with workers, dataloaders with samplers, with drop last and
+        #  without drop last and so on.
+        # TODO: Test more combinations of batch size schedulers.
+        # TODO: Check that create_dataloader throws errors when it should.
+
+    def test_constant_metric(self):
+        base_batch_size = 10
+        max_batch_size = 100
+
+        n_epochs = 100
+        metrics = [0.1] * n_epochs
+
+        dataloader = create_dataloader(self.dataset, batch_size=base_batch_size)
+        scheduler1 = IncreaseBSOnPlateau(dataloader, mode='min', threshold_mode='rel', max_batch_size=max_batch_size)
+        epoch_lengths1 = simulate_n_epochs(dataloader, scheduler1, metrics)
+
+        dataloader = create_dataloader(self.dataset, batch_size=base_batch_size)
+        scheduler2 = IncreaseBSOnPlateau(dataloader, mode='min', threshold_mode='abs', max_batch_size=max_batch_size)
+        epoch_lengths2 = simulate_n_epochs(dataloader, scheduler2, metrics)
+
+        dataloader = create_dataloader(self.dataset, batch_size=base_batch_size)
+        scheduler3 = IncreaseBSOnPlateau(dataloader, mode='max', threshold_mode='rel', max_batch_size=max_batch_size)
+        epoch_lengths3 = simulate_n_epochs(dataloader, scheduler3, metrics)
+
+        dataloader = create_dataloader(self.dataset, batch_size=base_batch_size)
+        scheduler4 = IncreaseBSOnPlateau(dataloader, mode='max', threshold_mode='abs', max_batch_size=max_batch_size)
+        epoch_lengths4 = simulate_n_epochs(dataloader, scheduler4, metrics)
+
+        expected_batch_sizes = [10] * 12 + [20] * 11 + [40] * 11 + [80] * 11 + [100] * 55
+        expected_lengths = self.compute_epoch_lengths(expected_batch_sizes, len(self.dataset), drop_last=False)
+        self.assertEqual(epoch_lengths1, expected_lengths)
+        self.assertEqual(epoch_lengths2, expected_lengths)
+        self.assertEqual(epoch_lengths3, expected_lengths)
+        self.assertEqual(epoch_lengths4, expected_lengths)
+
+        # TODO: Test different factors
+        # TODO: Test patience
+        # TODO: Test threshold
+        # TODO: Test threshold mode and mode
+        # TODO: Test cooldown
+
+
+if __name__ == "__main__":
+    from multiprocessing import freeze_support
+
+    freeze_support()
+    unittest.main()

--- a/tests/test_IncreaseBSOnPlateau.py
+++ b/tests/test_IncreaseBSOnPlateau.py
@@ -11,7 +11,6 @@ class TestIncreaseBSOnPlateau(BSTest):
         self.dataset = fashion_mnist()
         # TODO: Test multiple dataloaders: dataloader with workers, dataloaders with samplers, with drop last and
         #  without drop last and so on.
-        # TODO: Test more combinations of batch size schedulers.
         # TODO: Check that create_dataloader throws errors when it should.
 
     def test_constant_metric(self):

--- a/tests/test_IncreaseBSOnPlateau.py
+++ b/tests/test_IncreaseBSOnPlateau.py
@@ -19,7 +19,7 @@ class TestIncreaseBSOnPlateau(BSTest):
         max_batch_size = 100
 
         n_epochs = 100
-        metrics = [0.1] * n_epochs
+        metrics = [{"metric": 0.1}] * n_epochs
 
         dataloader = create_dataloader(self.dataset, batch_size=base_batch_size)
         scheduler1 = IncreaseBSOnPlateau(dataloader, mode='min', threshold_mode='rel', max_batch_size=max_batch_size)

--- a/tests/test_LambdaBS.py
+++ b/tests/test_LambdaBS.py
@@ -11,6 +11,7 @@ class TestLambdaBS(BSTest):
         self.dataset = fashion_mnist()
         # TODO: Test multiple dataloaders: dataloader with workers, dataloaders with samplers, with drop last and
         #  without drop last and so on.
+        # TODO: Test lambda with argument.
 
     @staticmethod
     def compute_expected_batch_sizes(epochs, base_batch_size, fn, min_batch_size, max_batch_size):

--- a/tests/test_MultiplicativeBS.py
+++ b/tests/test_MultiplicativeBS.py
@@ -11,6 +11,7 @@ class TestMultiplicativeBS(BSTest):
         self.dataset = fashion_mnist()
         # TODO: Test multiple dataloaders: dataloader with workers, dataloaders with samplers, with drop last and
         #  without drop last and so on.
+        # TODO: Test lambda with argument.
 
     @staticmethod
     def compute_expected_batch_sizes(epochs, base_batch_size, fn, min_batch_size, max_batch_size):

--- a/tests/test_SequentialBS.py
+++ b/tests/test_SequentialBS.py
@@ -16,7 +16,6 @@ class TestSequentialBS(BSTest):
         # TODO: Check that SequentialBS throws errors when it should.
 
     def test_dataloader_lengths(self):
-        # TODO: torch.optim.lr_scheduler.SequentialLR might be wrong: test it.
         base_batch_size = 10
         dataloader = create_dataloader(self.dataset, batch_size=base_batch_size)
         scheduler1 = ConstantBS(dataloader, factor=10, milestone=4)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -35,9 +35,14 @@ def iterate(dataloader):
 
 def simulate_n_epochs(dataloader, scheduler, epochs):
     lengths = []
-    for _ in range(epochs):
-        lengths.append(len(dataloader))
-        scheduler.step()
+    if isinstance(epochs, (tuple, list)):
+        for metric in epochs:
+            lengths.append(len(dataloader))
+            scheduler.step(metric=metric)
+    else:
+        for _ in range(epochs):
+            lengths.append(len(dataloader))
+            scheduler.step()
     return lengths
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -36,9 +36,9 @@ def iterate(dataloader):
 def simulate_n_epochs(dataloader, scheduler, epochs):
     lengths = []
     if isinstance(epochs, (tuple, list)):
-        for metric in epochs:
+        for d in epochs:
             lengths.append(len(dataloader))
-            scheduler.step(metric=metric)
+            scheduler.step(**d)
     else:
         for _ in range(epochs):
             lengths.append(len(dataloader))


### PR DESCRIPTION
## API Breaking Changes: 
  * The get_current_batch_size() function of `BSScheduler` was renamed to the 'batch_size' property. All usages have to be modified accordingly to reflect this change.
  * The finished() function of `BSScheduler` was renamed to the 'finished' property. All usages and overriding methods have to be modified accordingly to reflect this change.
  * The get_last_bs() function of `BSScheduler` was renamed to the 'last_bs' property. All usages have to be modified accordingly to reflect this change.
  * The get_bs() function of `BSScheduler` was renamed to the get_new_bs() function. All usages and overriding methods have to be modified accordingly to reflect this change. 
  * The definition of the step() function of `BSScheduler` was changed to accept keyword arguments which will be passed to the get_new_bs() function (formerly known as get_bs()) only if the get_new_bs() accepts keyword arguments. All overriding methods have to be modified accordingly to reflect this change.
  

## New features:
  * New schedulers, `ChainedBSScheduler` and `IncreaseBSOnPlateau`.
  * If the verbose flag is True, the message for the update of the batch size is displayed only if the new batch size is different than the previous batch size. 
  * The set_batch_size() function is now called only when the new batch size is different than the previous batch size.  
  * Setting the finished flag for `MultiStepBS` after the maximum milestone is reached.

## Other changes:
  * Documentation and type hint updates.
  * Functions from `BSScheduler` were reorder for better clarity.
  * `LambdaBS`, `MultiplicativeBS` call the super().load_state_dict() in their load_state_dict() function. 
  * Now also setting the batch size for the DataLoader when loading the state dict of `SequentialBS`.
  * The finished flag for `PolynomialBS` is now correctly set one epoch earlier.
  * The simulate_n_epochs() used in tests was updated to be able to pass keyword arguments to schedulers.
  * Bumping version and going from $\alpha$ to $\beta$. 