### PR TITLE
Added `CyclicBS` and tests.

### DIFF
--- a/bs_scheduler/__init__.py
+++ b/bs_scheduler/__init__.py
@@ -1,12 +1,12 @@
 from .batch_size_schedulers import LambdaBS, MultiplicativeBS, StepBS, MultiStepBS, ConstantBS, LinearBS, ExponentialBS, \
-    SequentialBS, PolynomialBS, CosineAnnealingBS, ChainedBSScheduler, IncreaseBSOnPlateau, BSScheduler, \
+    SequentialBS, PolynomialBS, CosineAnnealingBS, ChainedBSScheduler, IncreaseBSOnPlateau, CyclicBS, BSScheduler, \
     BatchSizeManager
 
 # We do not export DefaultBatchSizeManager and CustomBatchSizeManager because they are not needed. Users with custom
 # setups can create their own batch size managers.
 
 __all__ = ['LambdaBS', 'MultiplicativeBS', 'StepBS', 'MultiStepBS', 'ConstantBS', 'LinearBS', 'ExponentialBS',
-           'SequentialBS', 'PolynomialBS', 'CosineAnnealingBS', 'ChainedBSScheduler', 'IncreaseBSOnPlateau',
+           'SequentialBS', 'PolynomialBS', 'CosineAnnealingBS', 'ChainedBSScheduler', 'IncreaseBSOnPlateau', 'CyclicBS',
            'BSScheduler', 'BatchSizeManager']
 
 del batch_size_schedulers

--- a/bs_scheduler/batch_size_schedulers.py
+++ b/bs_scheduler/batch_size_schedulers.py
@@ -735,6 +735,8 @@ class SequentialBS(BSScheduler):
                                  f"scheduler at index {i} to have a different batch size manager. Expected type of "
                                  f"batch size manager: {type(self.batch_size_manager).__name__}, got: "
                                  f"{type(schedulers[i].batch_size_manager).__name__}.")
+            # TODO: Do we really need to raise an excetion if the maximum batch size is different for each scheduler?
+            # Maybe not, maybe we should just use max() and min().
             if schedulers[i].max_batch_size != self.max_batch_size:
                 raise ValueError(f"SequentialBS expects all schedulers to have the same maximum batch size, but got "
                                  f"scheduler at index {i} to have a different maximum batch size. Expected "
@@ -884,7 +886,7 @@ class CosineAnnealingBS(BSScheduler):
         min_batch_size (int): Lower limit for the batch size which must be greater than 0. Default: 1.
         verbose (bool): If ``True``, prints a message to stdout for each update. Default: ``False``.
 
-    .. _SGDR\: Stochastic Gradient Descent with Warm Restarts: https://arxiv.org/abs/1608.03983
+    .. _SGDR\\: Stochastic Gradient Descent with Warm Restarts: https://arxiv.org/abs/1608.03983
 
     Example:
         >>> dataloader = ...
@@ -906,7 +908,7 @@ class CosineAnnealingBS(BSScheduler):
         >>>     scheduler.step()
     """
 
-    def __init__(self, dataloader: DataLoader, total_iters: int, power: float = 1.0,
+    def __init__(self, dataloader: DataLoader, total_iters: int,
                  batch_size_manager: Union[BatchSizeManager, None] = None, max_batch_size: Union[int, None] = None,
                  min_batch_size: int = 1, verbose: bool = False):
         assert isinstance(total_iters, int) and total_iters > 1

--- a/bs_scheduler/batch_size_schedulers.py
+++ b/bs_scheduler/batch_size_schedulers.py
@@ -1,6 +1,8 @@
 # Inspired from https://pytorch.org/docs/stable/_modules/torch/optim/lr_scheduler.html.
 import inspect
 import math
+from functools import partial
+
 import torch
 import types
 from bisect import bisect_right

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "bs_scheduler"
-version = "0.2.0"
+version = "0.2.1"
 requires-python = ">=3.9"
 description = "A PyTorch Dataloader compatible batch size scheduler library."
 readme = "README.md"

--- a/tests/test_ChainedBSScheduler.py
+++ b/tests/test_ChainedBSScheduler.py
@@ -47,7 +47,7 @@ class TestChainedBSScheduler(BSTest):
         scheduler2 = ExponentialBS(dataloader, gamma=1.1)
         scheduler = ChainedBSScheduler([scheduler1, scheduler2])
 
-        self.loading_and_unloading(scheduler)
+        self.reloading_scheduler(scheduler)
         self.torch_save_and_load(scheduler)
         scheduler.step()
         self.assertEqual(scheduler.schedulers[0].factor, factor)

--- a/tests/test_ChainedBSScheduler.py
+++ b/tests/test_ChainedBSScheduler.py
@@ -40,6 +40,18 @@ class TestChainedBSScheduler(BSTest):
 
         self.assertEqual(batch_sizes, expected_batch_sizes)
 
+    def test_loading_and_unloading(self):
+        dataloader = create_dataloader(self.dataset)
+        factor = 10
+        scheduler1 = ConstantBS(dataloader, factor=factor, milestone=4)
+        scheduler2 = ExponentialBS(dataloader, gamma=1.1)
+        scheduler = ChainedBSScheduler([scheduler1, scheduler2])
+
+        self.loading_and_unloading(scheduler)
+        self.torch_save_and_load(scheduler)
+        scheduler.step()
+        self.assertEqual(scheduler.schedulers[0].factor, factor)
+
 
 if __name__ == "__main__":
     from multiprocessing import freeze_support

--- a/tests/test_ConstantBS.py
+++ b/tests/test_ConstantBS.py
@@ -44,7 +44,7 @@ class TestConstantBS(BSTest):
         milestone = 5
         scheduler = ConstantBS(dataloader, factor=factor, milestone=milestone, max_batch_size=100, verbose=True)
 
-        self.loading_and_unloading(scheduler)
+        self.reloading_scheduler(scheduler)
         self.torch_save_and_load(scheduler)
         scheduler.step()
         self.assertTrue(scheduler.verbose)

--- a/tests/test_ConstantBS.py
+++ b/tests/test_ConstantBS.py
@@ -38,6 +38,17 @@ class TestConstantBS(BSTest):
 
         self.assertEqual(batch_sizes, expected_batch_sizes)
 
+    def test_loading_and_unloading(self):
+        dataloader = create_dataloader(self.dataset)
+        factor = 5.0
+        milestone = 5
+        scheduler = ConstantBS(dataloader, factor=factor, milestone=milestone, max_batch_size=100, verbose=True)
+
+        self.loading_and_unloading(scheduler)
+        self.torch_save_and_load(scheduler)
+        scheduler.step()
+        self.assertTrue(scheduler.verbose)
+
 
 if __name__ == "__main__":
     from multiprocessing import freeze_support

--- a/tests/test_CosineAnnealingBS.py
+++ b/tests/test_CosineAnnealingBS.py
@@ -45,7 +45,7 @@ class TestCosineAnnealingBS(BSTest):
         max_batch_size = 100
         scheduler = CosineAnnealingBS(dataloader, total_iters=total_iters, max_batch_size=max_batch_size)
 
-        self.loading_and_unloading(scheduler)
+        self.reloading_scheduler(scheduler)
         self.torch_save_and_load(scheduler)
         scheduler.step()
         self.assertEqual(scheduler.max_batch_size, max_batch_size)

--- a/tests/test_CosineAnnealingBS.py
+++ b/tests/test_CosineAnnealingBS.py
@@ -39,6 +39,17 @@ class TestCosineAnnealingBS(BSTest):
 
         self.assertEqual(batch_sizes, expected_batch_sizes)
 
+    def test_loading_and_unloading(self):
+        dataloader = create_dataloader(self.dataset)
+        total_iters = 5
+        max_batch_size = 100
+        scheduler = CosineAnnealingBS(dataloader, total_iters=total_iters, max_batch_size=max_batch_size)
+
+        self.loading_and_unloading(scheduler)
+        self.torch_save_and_load(scheduler)
+        scheduler.step()
+        self.assertEqual(scheduler.max_batch_size, max_batch_size)
+
 
 if __name__ == "__main__":
     from multiprocessing import freeze_support

--- a/tests/test_CyclicBS.py
+++ b/tests/test_CyclicBS.py
@@ -108,7 +108,7 @@ class TestConstantBS(BSTest):
         dataloader = create_dataloader(self.dataset)
         upper_batch_size = 300
         scheduler = CyclicBS(dataloader, dataloader.batch_size, upper_batch_size, mode='triangular')
-        self.loading_and_unloading(scheduler)
+        self.reloading_scheduler(scheduler)
         self.torch_save_and_load(scheduler)
         scheduler.step()
         self.assertEqual(scheduler.scale_fn(rint(random.random() * 1000)), 1.0)
@@ -117,7 +117,7 @@ class TestConstantBS(BSTest):
         dataloader = create_dataloader(self.dataset)
         upper_batch_size = 300
         scheduler = CyclicBS(dataloader, dataloader.batch_size, upper_batch_size, mode='triangular2')
-        self.loading_and_unloading(scheduler)
+        self.reloading_scheduler(scheduler)
         self.torch_save_and_load(scheduler)
         scheduler.step()
         self.assertEqual(scheduler.scale_fn(2), 0.5)
@@ -129,7 +129,7 @@ class TestConstantBS(BSTest):
         upper_batch_size = 300
         gamma = 1.1
         scheduler = CyclicBS(dataloader, dataloader.batch_size, upper_batch_size, mode='exp_range', gamma=gamma)
-        self.loading_and_unloading(scheduler)
+        self.reloading_scheduler(scheduler)
         self.torch_save_and_load(scheduler)
         scheduler.step()
         self.assertEqual(scheduler.scale_fn(2), gamma ** 2.0)
@@ -140,7 +140,7 @@ class TestConstantBS(BSTest):
         dataloader = create_dataloader(self.dataset)
         upper_batch_size = 300
         scheduler = CyclicBS(dataloader, dataloader.batch_size, upper_batch_size, scale_fn=lambda x: 0.25)
-        self.loading_and_unloading(scheduler)
+        self.reloading_scheduler(scheduler)
         self.torch_save_and_load(scheduler)
         scheduler.step()
         self.assertEqual(scheduler.scale_fn(rint(random.random() * 1000)), 0.25)

--- a/tests/test_CyclicBS.py
+++ b/tests/test_CyclicBS.py
@@ -1,0 +1,153 @@
+import random
+import unittest
+
+from bs_scheduler import CyclicBS
+from tests.test_utils import create_dataloader, simulate_n_epochs, fashion_mnist, \
+    get_batch_sizes_across_epochs, BSTest, rint
+
+
+class TestConstantBS(BSTest):
+    def setUp(self):
+        self.base_batch_size = 64
+        self.dataset = fashion_mnist()
+        # TODO: Test multiple dataloaders: dataloader with workers, dataloaders with samplers, with drop last and
+        #  without drop last and so on.
+
+    def test_dataloader_batch_size_triangular(self):
+        base_batch_size = 10
+        dataloader = create_dataloader(self.dataset, batch_size=base_batch_size)
+        upper_batch_size_bound = 100
+        step_size_up = 10
+        scheduler = CyclicBS(dataloader, base_batch_size=base_batch_size, upper_batch_size_bound=upper_batch_size_bound,
+                             step_size_up=step_size_up, mode='triangular')
+        n_epochs = 4 * step_size_up
+
+        batch_sizes = get_batch_sizes_across_epochs(dataloader, scheduler, n_epochs)
+
+        step = rint((upper_batch_size_bound - base_batch_size) / step_size_up)
+        increasing_range = list(range(base_batch_size, upper_batch_size_bound, step))
+        decreasing_range = list(range(upper_batch_size_bound, base_batch_size, -step))
+        expected_batch_sizes = (increasing_range + decreasing_range) * 2
+
+        self.assertEqual(batch_sizes, expected_batch_sizes)
+
+    def test_dataloader_batch_size_triangular2(self):
+        base_batch_size = 10
+        dataloader = create_dataloader(self.dataset, batch_size=base_batch_size)
+        upper_batch_size_bound = 100
+        step_size_up = 10
+        scheduler = CyclicBS(dataloader, base_batch_size=base_batch_size, upper_batch_size_bound=upper_batch_size_bound,
+                             step_size_up=step_size_up, mode='triangular2')
+        n_epochs = 4 * step_size_up
+
+        batch_sizes = get_batch_sizes_across_epochs(dataloader, scheduler, n_epochs)
+
+        step = rint((upper_batch_size_bound - base_batch_size) / step_size_up)
+        increasing_range = list(range(base_batch_size, upper_batch_size_bound, step))
+        decreasing_range = list(range(upper_batch_size_bound, base_batch_size, -step))
+        increasing_range_2 = [base_batch_size]
+        for _ in range(step_size_up - 1):
+            increasing_range_2.append(increasing_range_2[-1] + step / 2.0)
+
+        increasing_range_2[3] -= 1e-8  # Rounding errors ...
+        increasing_range_2[9] += 1e-8  # Rounding errors ...
+        # I don't know if this generalizes for other pairs of base batch size and upper batch size.
+        # TODO: Find a solution for better numerical stability.
+
+        decreasing_range_2 = [increasing_range_2[-1] + step / 2.0] + list(reversed(increasing_range_2))[
+                                                                     :step_size_up - 1]
+        increasing_range_2 = list(map(rint, increasing_range_2))
+        decreasing_range_2 = list(map(rint, decreasing_range_2))
+        expected_batch_sizes = increasing_range + decreasing_range + increasing_range_2 + decreasing_range_2
+
+        self.assertEqual(batch_sizes, expected_batch_sizes)
+
+    def test_dataloader_batch_size_exp_range(self):
+        base_batch_size = 10
+        dataloader = create_dataloader(self.dataset, batch_size=base_batch_size)
+        upper_batch_size_bound = 100
+        step_size_up = 10
+        gamma = 0.9
+        scheduler = CyclicBS(dataloader, base_batch_size=base_batch_size, upper_batch_size_bound=upper_batch_size_bound,
+                             step_size_up=step_size_up, mode='exp_range', gamma=gamma)
+        n_epochs = 4 * step_size_up
+
+        batch_sizes = get_batch_sizes_across_epochs(dataloader, scheduler, n_epochs)
+
+        def calculate_increasing_and_decreasing_range(base_batch_size, step_size_up, step, count):
+            increasing_range = [base_batch_size]
+            count += 1
+            for i in range(1, step_size_up):
+                increasing_range.append(base_batch_size + step * i * gamma ** count)
+                count += 1
+            decreasing_range = [base_batch_size + step * step_size_up * gamma ** count]
+            count += 1
+            for i in range(step_size_up - 1, 0, -1):
+                decreasing_range.append(base_batch_size + step * i * gamma ** count)
+                count += 1
+
+            return increasing_range, decreasing_range, count
+
+        step = rint((upper_batch_size_bound - base_batch_size) / step_size_up)
+        count = 0
+
+        increasing_range, decreasing_range, count = calculate_increasing_and_decreasing_range(
+            base_batch_size, step_size_up, step, count)
+        increasing_range_2, decreasing_range_2, count = calculate_increasing_and_decreasing_range(
+            base_batch_size, step_size_up, step, count)
+
+        increasing_range = list(map(rint, increasing_range))
+        decreasing_range = list(map(rint, decreasing_range))
+        increasing_range_2 = list(map(rint, increasing_range_2))
+        decreasing_range_2 = list(map(rint, decreasing_range_2))
+        expected_batch_sizes = increasing_range + decreasing_range + increasing_range_2 + decreasing_range_2
+
+        self.assertEqual(batch_sizes, expected_batch_sizes)
+
+    def test_loading_and_unloading_triangular(self):
+        dataloader = create_dataloader(self.dataset)
+        upper_batch_size = 300
+        scheduler = CyclicBS(dataloader, dataloader.batch_size, upper_batch_size, mode='triangular')
+        self.loading_and_unloading(scheduler)
+        self.torch_save_and_load(scheduler)
+        scheduler.step()
+        self.assertEqual(scheduler.scale_fn(rint(random.random() * 1000)), 1.0)
+
+    def test_loading_and_unloading_triangular2(self):
+        dataloader = create_dataloader(self.dataset)
+        upper_batch_size = 300
+        scheduler = CyclicBS(dataloader, dataloader.batch_size, upper_batch_size, mode='triangular2')
+        self.loading_and_unloading(scheduler)
+        self.torch_save_and_load(scheduler)
+        scheduler.step()
+        self.assertEqual(scheduler.scale_fn(2), 0.5)
+        self.assertEqual(scheduler.scale_fn(1), 1.0)
+        self.assertEqual(scheduler.scale_fn(3), 0.25)
+
+    def test_loading_and_unloading_exp_range(self):
+        dataloader = create_dataloader(self.dataset)
+        upper_batch_size = 300
+        gamma = 1.1
+        scheduler = CyclicBS(dataloader, dataloader.batch_size, upper_batch_size, mode='exp_range', gamma=gamma)
+        self.loading_and_unloading(scheduler)
+        self.torch_save_and_load(scheduler)
+        scheduler.step()
+        self.assertEqual(scheduler.scale_fn(2), gamma ** 2.0)
+        self.assertEqual(scheduler.scale_fn(1), gamma ** 1.0)
+        self.assertEqual(scheduler.scale_fn(3), gamma ** 3.0)
+
+    def test_loading_and_unloading_scale_fn(self):
+        dataloader = create_dataloader(self.dataset)
+        upper_batch_size = 300
+        scheduler = CyclicBS(dataloader, dataloader.batch_size, upper_batch_size, scale_fn=lambda x: 0.25)
+        self.loading_and_unloading(scheduler)
+        self.torch_save_and_load(scheduler)
+        scheduler.step()
+        self.assertEqual(scheduler.scale_fn(rint(random.random() * 1000)), 0.25)
+
+
+if __name__ == "__main__":
+    from multiprocessing import freeze_support
+
+    freeze_support()
+    unittest.main()

--- a/tests/test_ExponentialBS.py
+++ b/tests/test_ExponentialBS.py
@@ -39,7 +39,7 @@ class TestExponentialBS(BSTest):
         gamma = 2
         scheduler = ExponentialBS(dataloader, gamma=gamma, max_batch_size=100, verbose=False)
 
-        self.loading_and_unloading(scheduler)
+        self.reloading_scheduler(scheduler)
         self.torch_save_and_load(scheduler)
         scheduler.step()
         self.assertEqual(scheduler.gamma, gamma)

--- a/tests/test_ExponentialBS.py
+++ b/tests/test_ExponentialBS.py
@@ -34,6 +34,16 @@ class TestExponentialBS(BSTest):
 
         self.assertEqual(batch_sizes, expected_batch_sizes)
 
+    def test_loading_and_unloading(self):
+        dataloader = create_dataloader(self.dataset)
+        gamma = 2
+        scheduler = ExponentialBS(dataloader, gamma=gamma, max_batch_size=100, verbose=False)
+
+        self.loading_and_unloading(scheduler)
+        self.torch_save_and_load(scheduler)
+        scheduler.step()
+        self.assertEqual(scheduler.gamma, gamma)
+
 
 if __name__ == "__main__":
     from multiprocessing import freeze_support

--- a/tests/test_IncreaseBSOnPlateau.py
+++ b/tests/test_IncreaseBSOnPlateau.py
@@ -55,7 +55,7 @@ class TestIncreaseBSOnPlateau(BSTest):
         threshold_mode = 'rel'
         scheduler = IncreaseBSOnPlateau(dataloader, mode=mode, threshold_mode=threshold_mode)
 
-        self.loading_and_unloading(scheduler)
+        self.reloading_scheduler(scheduler)
         self.torch_save_and_load(scheduler)
         scheduler.step(metric=10)
         self.assertEqual(scheduler.mode, mode)

--- a/tests/test_IncreaseBSOnPlateau.py
+++ b/tests/test_IncreaseBSOnPlateau.py
@@ -49,6 +49,18 @@ class TestIncreaseBSOnPlateau(BSTest):
         # TODO: Test threshold mode and mode
         # TODO: Test cooldown
 
+    def test_loading_and_unloading(self):
+        dataloader = create_dataloader(self.dataset)
+        mode = 'min'
+        threshold_mode = 'rel'
+        scheduler = IncreaseBSOnPlateau(dataloader, mode=mode, threshold_mode=threshold_mode)
+
+        self.loading_and_unloading(scheduler)
+        self.torch_save_and_load(scheduler)
+        scheduler.step(metric=10)
+        self.assertEqual(scheduler.mode, mode)
+        self.assertEqual(scheduler.threshold_mode, threshold_mode)
+
 
 if __name__ == "__main__":
     from multiprocessing import freeze_support

--- a/tests/test_LambdaBS.py
+++ b/tests/test_LambdaBS.py
@@ -55,6 +55,17 @@ class TestLambdaBS(BSTest):
                                                                  scheduler.min_batch_size, scheduler.max_batch_size)
         self.assertEqual(batch_sizes, expected_batch_sizes)
 
+    def test_loading_and_unloading(self):
+        dataloader = create_dataloader(self.dataset)
+        fn = lambda epoch: 10 * epoch
+        scheduler = LambdaBS(dataloader, fn)
+
+        self.loading_and_unloading(scheduler)
+        self.torch_save_and_load(scheduler)
+        scheduler.step()
+        # TODO: Test that function objects are saved and can work again
+        self.assertEqual(scheduler.bs_lambda(10), 100)
+
 
 if __name__ == "__main__":
     from multiprocessing import freeze_support

--- a/tests/test_LambdaBS.py
+++ b/tests/test_LambdaBS.py
@@ -60,7 +60,7 @@ class TestLambdaBS(BSTest):
         fn = lambda epoch: 10 * epoch
         scheduler = LambdaBS(dataloader, fn)
 
-        self.loading_and_unloading(scheduler)
+        self.reloading_scheduler(scheduler)
         self.torch_save_and_load(scheduler)
         scheduler.step()
         # TODO: Test that function objects are saved and can work again

--- a/tests/test_LinearBS.py
+++ b/tests/test_LinearBS.py
@@ -15,7 +15,8 @@ class TestLinearBS(BSTest):
         #  without drop last and so on.
 
     @staticmethod
-    def compute_expected_batch_sizes(epochs, base_batch_size, start_factor, end_factor, milestone, min_batch_size, max_batch_size):
+    def compute_expected_batch_sizes(epochs, base_batch_size, start_factor, end_factor, milestone, min_batch_size,
+                                     max_batch_size):
         expected_batch_sizes = [base_batch_size]  # Base batch size is added as a boundary condition.
         factors = torch.linspace(start_factor, end_factor, milestone + 1)
         factors[1:] = factors[1:] / factors[:-1]
@@ -35,11 +36,16 @@ class TestLinearBS(BSTest):
         start_factor = 12.0
         end_factor = 3.0
         milestone = 5
-        scheduler = LinearBS(dataloader, verbose=False, start_factor=start_factor, end_factor=end_factor, milestone=milestone)
+        scheduler = LinearBS(dataloader, verbose=False, start_factor=start_factor, end_factor=end_factor,
+                             milestone=milestone)
         n_epochs = 10
 
         epoch_lengths = simulate_n_epochs(dataloader, scheduler, n_epochs)
-        expected_batch_sizes = self.compute_expected_batch_sizes(n_epochs, self.base_batch_size, start_factor=start_factor, end_factor=end_factor, milestone=milestone, min_batch_size=scheduler.min_batch_size, max_batch_size=scheduler.max_batch_size)
+        expected_batch_sizes = self.compute_expected_batch_sizes(n_epochs, self.base_batch_size,
+                                                                 start_factor=start_factor, end_factor=end_factor,
+                                                                 milestone=milestone,
+                                                                 min_batch_size=scheduler.min_batch_size,
+                                                                 max_batch_size=scheduler.max_batch_size)
         expected_lengths = self.compute_epoch_lengths(expected_batch_sizes, len(self.dataset), drop_last=False)
         self.assertEqual(epoch_lengths, expected_lengths)
 
@@ -49,13 +55,27 @@ class TestLinearBS(BSTest):
         start_factor = 6.0
         end_factor = 1.0
         milestone = 5
-        scheduler = LinearBS(dataloader, start_factor=start_factor, end_factor=end_factor, milestone=milestone, max_batch_size=100, verbose=False)
+        scheduler = LinearBS(dataloader, start_factor=start_factor, end_factor=end_factor, milestone=milestone,
+                             max_batch_size=100, verbose=False)
         n_epochs = 15
 
         batch_sizes = get_batch_sizes_across_epochs(dataloader, scheduler, n_epochs)
         expected_batch_sizes = [60, 50, 40, 30, 20] + [10] * 10
 
         self.assertEqual(batch_sizes, expected_batch_sizes)
+
+    def test_loading_and_unloading(self):
+        dataloader = create_dataloader(self.dataset)
+        start_factor = 6.0
+        end_factor = 1.0
+        milestone = 5
+        scheduler = LinearBS(dataloader, start_factor=start_factor, end_factor=end_factor, milestone=milestone,
+                             max_batch_size=100, verbose=False)
+
+        self.loading_and_unloading(scheduler)
+        self.torch_save_and_load(scheduler)
+        scheduler.step()
+        self.assertEqual(scheduler.milestone, milestone)
 
 
 if __name__ == "__main__":

--- a/tests/test_LinearBS.py
+++ b/tests/test_LinearBS.py
@@ -72,7 +72,7 @@ class TestLinearBS(BSTest):
         scheduler = LinearBS(dataloader, start_factor=start_factor, end_factor=end_factor, milestone=milestone,
                              max_batch_size=100, verbose=False)
 
-        self.loading_and_unloading(scheduler)
+        self.reloading_scheduler(scheduler)
         self.torch_save_and_load(scheduler)
         scheduler.step()
         self.assertEqual(scheduler.milestone, milestone)

--- a/tests/test_MultiStepBS.py
+++ b/tests/test_MultiStepBS.py
@@ -50,6 +50,17 @@ class TestMultiStepBS(BSTest):
 
         self.assertEqual(batch_sizes, expected_batch_sizes)
 
+    def test_loading_and_unloading(self):
+        dataloader = create_dataloader(self.dataset)
+        milestones = [5, 10, 10, 12]
+        gamma = 3.0
+        scheduler = MultiStepBS(dataloader, milestones=milestones, gamma=gamma, max_batch_size=5000, verbose=False)
+
+        self.loading_and_unloading(scheduler)
+        self.torch_save_and_load(scheduler)
+        scheduler.step()
+        self.assertEqual(scheduler.gamma, gamma)
+
 
 if __name__ == "__main__":
     from multiprocessing import freeze_support

--- a/tests/test_MultiStepBS.py
+++ b/tests/test_MultiStepBS.py
@@ -56,7 +56,7 @@ class TestMultiStepBS(BSTest):
         gamma = 3.0
         scheduler = MultiStepBS(dataloader, milestones=milestones, gamma=gamma, max_batch_size=5000, verbose=False)
 
-        self.loading_and_unloading(scheduler)
+        self.reloading_scheduler(scheduler)
         self.torch_save_and_load(scheduler)
         scheduler.step()
         self.assertEqual(scheduler.gamma, gamma)

--- a/tests/test_MultiplicativeBS.py
+++ b/tests/test_MultiplicativeBS.py
@@ -53,7 +53,7 @@ class TestMultiplicativeBS(BSTest):
         fn = lambda epoch: 10 * epoch
         scheduler = MultiplicativeBS(dataloader, fn)
 
-        self.loading_and_unloading(scheduler)
+        self.reloading_scheduler(scheduler)
         self.torch_save_and_load(scheduler)
         scheduler.step()
         # TODO: Test that function objects are saved and can work again

--- a/tests/test_MultiplicativeBS.py
+++ b/tests/test_MultiplicativeBS.py
@@ -48,6 +48,17 @@ class TestMultiplicativeBS(BSTest):
 
         self.assertEqual(batch_sizes, expected_batch_sizes)
 
+    def test_loading_and_unloading(self):
+        dataloader = create_dataloader(self.dataset)
+        fn = lambda epoch: 10 * epoch
+        scheduler = MultiplicativeBS(dataloader, fn)
+
+        self.loading_and_unloading(scheduler)
+        self.torch_save_and_load(scheduler)
+        scheduler.step()
+        # TODO: Test that function objects are saved and can work again
+        self.assertEqual(scheduler.bs_lambda(10), 100)
+
 
 if __name__ == "__main__":
     from multiprocessing import freeze_support

--- a/tests/test_PolynomialBS.py
+++ b/tests/test_PolynomialBS.py
@@ -44,7 +44,7 @@ class TestPolynomialBS(BSTest):
         power = 1.0
         scheduler = PolynomialBS(dataloader, total_iters=total_iters, power=power, verbose=False)
 
-        self.loading_and_unloading(scheduler)
+        self.reloading_scheduler(scheduler)
         self.torch_save_and_load(scheduler)
         scheduler.step()
         self.assertEqual(scheduler.power, power)

--- a/tests/test_PolynomialBS.py
+++ b/tests/test_PolynomialBS.py
@@ -38,6 +38,17 @@ class TestPolynomialBS(BSTest):
 
         self.assertEqual(batch_sizes, expected_batch_sizes)
 
+    def test_loading_and_unloading(self):
+        dataloader = create_dataloader(self.dataset)
+        total_iters = 10
+        power = 1.0
+        scheduler = PolynomialBS(dataloader, total_iters=total_iters, power=power, verbose=False)
+
+        self.loading_and_unloading(scheduler)
+        self.torch_save_and_load(scheduler)
+        scheduler.step()
+        self.assertEqual(scheduler.power, power)
+
 
 if __name__ == "__main__":
     from multiprocessing import freeze_support

--- a/tests/test_SequentialBS.py
+++ b/tests/test_SequentialBS.py
@@ -101,7 +101,7 @@ class TestSequentialBS(BSTest):
         scheduler2 = ExponentialBS(dataloader, gamma=2, verbose=False)
         scheduler = SequentialBS(dataloader, schedulers=[scheduler1, scheduler2], milestones=[5])
 
-        self.loading_and_unloading(scheduler)
+        self.reloading_scheduler(scheduler)
         self.torch_save_and_load(scheduler)
         scheduler.step()
         self.assertEqual(len(scheduler.schedulers), 2)

--- a/tests/test_SequentialBS.py
+++ b/tests/test_SequentialBS.py
@@ -94,6 +94,19 @@ class TestSequentialBS(BSTest):
             SequentialBS(dataloader, schedulers=[other_scheduler, scheduler2, scheduler3], milestones=[5, 10],
                          max_batch_size=100)
 
+    def test_loading_and_unloading(self):
+        dataloader = create_dataloader(self.dataset)
+        factor = 10
+        scheduler1 = ConstantBS(dataloader, factor=factor, milestone=4)
+        scheduler2 = ExponentialBS(dataloader, gamma=2, verbose=False)
+        scheduler = SequentialBS(dataloader, schedulers=[scheduler1, scheduler2], milestones=[5])
+
+        self.loading_and_unloading(scheduler)
+        self.torch_save_and_load(scheduler)
+        scheduler.step()
+        self.assertEqual(len(scheduler.schedulers), 2)
+        self.assertEqual(scheduler.schedulers[0].factor, factor)
+
 
 if __name__ == "__main__":
     from multiprocessing import freeze_support

--- a/tests/test_StepBS.py
+++ b/tests/test_StepBS.py
@@ -57,7 +57,7 @@ class TestStepBS(BSTest):
         gamma = 3.0
         scheduler = StepBS(dataloader, step_size=step_size, gamma=gamma, max_batch_size=5000, verbose=False)
 
-        self.loading_and_unloading(scheduler)
+        self.reloading_scheduler(scheduler)
         self.torch_save_and_load(scheduler)
         scheduler.step()
         self.assertEqual(scheduler.step_size, step_size)

--- a/tests/test_StepBS.py
+++ b/tests/test_StepBS.py
@@ -51,6 +51,18 @@ class TestStepBS(BSTest):
 
         self.assertEqual(batch_sizes, expected_batch_sizes)
 
+    def test_loading_and_unloading(self):
+        dataloader = create_dataloader(self.dataset)
+        step_size = 5
+        gamma = 3.0
+        scheduler = StepBS(dataloader, step_size=step_size, gamma=gamma, max_batch_size=5000, verbose=False)
+
+        self.loading_and_unloading(scheduler)
+        self.torch_save_and_load(scheduler)
+        scheduler.step()
+        self.assertEqual(scheduler.step_size, step_size)
+
+
 
 if __name__ == "__main__":
     from multiprocessing import freeze_support

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,10 +1,14 @@
 import math
+import os
+import tempfile
 import unittest
 
 import torch
 from torchvision import datasets
 from torchvision.transforms import ToTensor
 from torch.utils.data import DataLoader
+
+from bs_scheduler import BSScheduler
 
 
 def fashion_mnist():
@@ -82,3 +86,22 @@ class BSTest(unittest.TestCase):
         if drop_last:
             return [dataset_len // bs for bs in batch_sizes]
         return [int(math.ceil(dataset_len / bs)) for bs in batch_sizes]
+
+    @staticmethod
+    def loading_and_unloading(scheduler: BSScheduler):
+        state_dict = scheduler.state_dict()
+        scheduler.load_state_dict(state_dict)
+
+    @staticmethod
+    def torch_save_and_load(scheduler: BSScheduler):
+        state_dict = scheduler.state_dict()
+        # on os.name == 'nt' we can't open a named temporary file twice
+        tmp = tempfile.NamedTemporaryFile(delete=False)
+        try:
+            torch.save(state_dict, tmp.name)
+            state_dict = torch.load(tmp.name)
+        finally:
+            tmp.close()
+            os.unlink(tmp.name)
+
+        scheduler.load_state_dict(state_dict)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -88,7 +88,7 @@ class BSTest(unittest.TestCase):
         return [int(math.ceil(dataset_len / bs)) for bs in batch_sizes]
 
     @staticmethod
-    def loading_and_unloading(scheduler: BSScheduler):
+    def reloading_scheduler(scheduler: BSScheduler):
         state_dict = scheduler.state_dict()
         scheduler.load_state_dict(state_dict)
 


### PR DESCRIPTION
## Other changes
* Added a _init_get_new_bs() function to `BSScheduler` that initializes the _internal_get_new_bs member variable and is called both in the constructor and load_state_dict() function. 
* The state_dict() function of `BSScheduler` removes the `_internal_get_new_bs` member variable from the state_dict, fixing a pickling bug.
* `LambdaBS`, `MultiplicativeBS` and `CosineAnnealingBS` now use super().state_dict() in their state_dict() function.
* Added tests which use torch.save and torch.load to save and load the scheduler states. 
* Documentation and comments update.
* Bumping version.