### PR TITLE
Added `CosineAnnealingBSWithWarmRestarts` and `OneCycleBS`

### DIFF
--- a/bs_scheduler/__init__.py
+++ b/bs_scheduler/__init__.py
@@ -1,12 +1,12 @@
 from .batch_size_schedulers import LambdaBS, MultiplicativeBS, StepBS, MultiStepBS, ConstantBS, LinearBS, ExponentialBS, \
-    SequentialBS, PolynomialBS, CosineAnnealingBS, ChainedBSScheduler, IncreaseBSOnPlateau, CyclicBS, BSScheduler, \
-    BatchSizeManager
+    SequentialBS, PolynomialBS, CosineAnnealingBS, ChainedBSScheduler, IncreaseBSOnPlateau, CyclicBS, \
+    CosineAnnealingBSWithWarmRestarts, BSScheduler, BatchSizeManager
 
 # We do not export DefaultBatchSizeManager and CustomBatchSizeManager because they are not needed. Users with custom
 # setups can create their own batch size managers.
 
 __all__ = ['LambdaBS', 'MultiplicativeBS', 'StepBS', 'MultiStepBS', 'ConstantBS', 'LinearBS', 'ExponentialBS',
            'SequentialBS', 'PolynomialBS', 'CosineAnnealingBS', 'ChainedBSScheduler', 'IncreaseBSOnPlateau', 'CyclicBS',
-           'BSScheduler', 'BatchSizeManager']
+           'CosineAnnealingBSWithWarmRestarts', 'BSScheduler', 'BatchSizeManager']
 
 del batch_size_schedulers

--- a/bs_scheduler/__init__.py
+++ b/bs_scheduler/__init__.py
@@ -1,12 +1,12 @@
 from .batch_size_schedulers import LambdaBS, MultiplicativeBS, StepBS, MultiStepBS, ConstantBS, LinearBS, ExponentialBS, \
     SequentialBS, PolynomialBS, CosineAnnealingBS, ChainedBSScheduler, IncreaseBSOnPlateau, CyclicBS, \
-    CosineAnnealingBSWithWarmRestarts, BSScheduler, BatchSizeManager
+    CosineAnnealingBSWithWarmRestarts, OneCycleBS, BSScheduler, BatchSizeManager
 
 # We do not export DefaultBatchSizeManager and CustomBatchSizeManager because they are not needed. Users with custom
 # setups can create their own batch size managers.
 
 __all__ = ['LambdaBS', 'MultiplicativeBS', 'StepBS', 'MultiStepBS', 'ConstantBS', 'LinearBS', 'ExponentialBS',
            'SequentialBS', 'PolynomialBS', 'CosineAnnealingBS', 'ChainedBSScheduler', 'IncreaseBSOnPlateau', 'CyclicBS',
-           'CosineAnnealingBSWithWarmRestarts', 'BSScheduler', 'BatchSizeManager']
+           'CosineAnnealingBSWithWarmRestarts', 'OneCycleBS', 'BSScheduler', 'BatchSizeManager']
 
 del batch_size_schedulers

--- a/bs_scheduler/batch_size_schedulers.py
+++ b/bs_scheduler/batch_size_schedulers.py
@@ -1,14 +1,13 @@
 # Inspired from https://pytorch.org/docs/stable/_modules/torch/optim/lr_scheduler.html.
 import inspect
 import math
-from functools import partial
-
-import torch
 import types
 from bisect import bisect_right
 from collections import Counter
+from functools import partial
 from typing import Callable, Union, Sequence, Tuple
 
+import torch
 from torch.utils.data import DataLoader, Dataset
 
 __all__ = ['LambdaBS', 'MultiplicativeBS', 'StepBS', 'MultiStepBS', 'ConstantBS', 'LinearBS', 'ExponentialBS',
@@ -740,16 +739,12 @@ class SequentialBS(BSScheduler):
                                  f"scheduler at index {i} to have a different batch size manager. Expected type of "
                                  f"batch size manager: {type(self.batch_size_manager).__name__}, got: "
                                  f"{type(schedulers[i].batch_size_manager).__name__}.")
-            # TODO: Do we really need to raise an error if the maximum batch size is different for each scheduler?
-            # Maybe not, maybe we should just use max() and min().
-            if schedulers[i].max_batch_size != self.max_batch_size:
-                raise ValueError(f"SequentialBS expects all schedulers to have the same maximum batch size, but got "
-                                 f"scheduler at index {i} to have a different maximum batch size. Expected "
-                                 f"{self.max_batch_size}, got {schedulers[i].max_batch_size}.")
-            if schedulers[i].min_batch_size != self.min_batch_size:
-                raise ValueError(f"SequentialBS expects all schedulers to have the same minimum batch size, but got "
-                                 f"scheduler at index {i} to have a different minimum batch size. Expected "
-                                 f"{self.min_batch_size}, got {schedulers[i].min_batch_size}.")
+
+            if schedulers[i].max_batch_size > self.max_batch_size:
+                self.max_batch_size = schedulers[i].max_batch_size
+            if schedulers[i].min_batch_size < self.min_batch_size:
+               self.min_batch_size = schedulers[i].min_batch_size
+
             # Undoing the steps done by the schedulers.
             schedulers[i]._last_bs = self.dataloader._base_batch_size
             schedulers[i].last_epoch -= 1
@@ -883,6 +878,8 @@ class CosineAnnealingBS(BSScheduler):
     Args:
         dataloader (DataLoader): Wrapped dataloader.
         total_iters (int): The number of steps that the scheduler increases the batch size.
+        base_batch_size (Union[int, None]): The base batch size. If None, the base batch size will be retrieved from
+            the dataloader. Default: None.
         batch_size_manager (Union[BatchSizeManager, None]): If not None, a custom class which manages the batch size,
             which provides a getter and setter for the batch size. Default: None.
         max_batch_size (Union[int, None]): Upper limit for the batch size so that a batch of size max_batch_size fits
@@ -913,17 +910,16 @@ class CosineAnnealingBS(BSScheduler):
         >>>     scheduler.step()
     """
 
-    def __init__(self, dataloader: DataLoader, total_iters: int,
+    def __init__(self, dataloader: DataLoader, total_iters: int, base_batch_size: Union[int, None] = None,
                  batch_size_manager: Union[BatchSizeManager, None] = None, max_batch_size: Union[int, None] = None,
                  min_batch_size: int = 1, verbose: bool = False):
         assert isinstance(total_iters, int) and total_iters > 1
-
-        # Should we accept the base_batch_size and upper_batch_size as parameters, and use upper_batch_size instead of
-        # max batch size?
+        assert base_batch_size is None or (isinstance(base_batch_size, int) and base_batch_size >= min_batch_size)
 
         self.total_iters: int = total_iters
         super().__init__(dataloader, batch_size_manager, max_batch_size, min_batch_size, verbose)
-        self.base_batch_size: int = self.dataloader._base_batch_size
+        self.base_batch_size: int = self.dataloader._base_batch_size if base_batch_size is None else base_batch_size
+        assert self.max_batch_size > self.base_batch_size
 
     def get_new_bs(self) -> int:
         """ Returns the next batch size as an :class:`int`. Increases the batch size from base batch size to maximum
@@ -1224,13 +1220,8 @@ class CyclicBS(BSScheduler):
 
     Args:
         dataloader (DataLoader): Wrapped dataloader.
-        base_batch_size (int): Initial batch size which is the lower boundery in the cycle.
-        # Do we really need this parameter? Don't we already have base batch size?
-        upper_batch_size_bound (int): Upper batch size boundary in the cycle. Functionally, it defines the cycle
-            amplitude (upper_batch_size_bound - base_batch_size). The batch size at any cycle is the sum of
-            base_batch_size and some scaling of the amplitude; therefore, upper_batch_size_bound may not actually be
-            reached depending on scaling function.
-        # Do we really need this parameter? Can't we just use max_batch_size?
+        base_batch_size (Union[int, None]): Initial batch size which is the lower boundery in the cycle. If None, the
+            base batch size will be retrieved from the dataloader. Default: None.
         step_size_up (int): Number of training iterations in the increasing half of a cycle. Default: 2000.
         step_size_down (Union[int, None]): Number of training iterations in the decreasing half of a cycle. If
             step_size_down is None, it is set to step_size_up. Default: None.
@@ -1244,9 +1235,11 @@ class CyclicBS(BSScheduler):
             automatically set to 'iterations' if mode is 'exp_range' and 'cycle' otherwhise. Default: 'cycle'.
         batch_size_manager (Union[BatchSizeManager, None]): If not None, a custom class which manages the batch size,
             which provides a getter and setter for the batch size. Default: None.
-        max_batch_size (Union[int, None]): Upper limit for the batch size so that a batch of size max_batch_size fits
-            in the memory. If None or greater than the lenght of the dataset wrapped by the dataloader, max_batch_size
-            is set to `len(self.dataloader.dataset)`. Default: None.
+        max_batch_size (Union[int, None]): Upper batch size boundary in the cycle. Functionally, it defines the cycle
+            amplitude (upper_batch_size_bound - base_batch_size). The batch size at any cycle is the sum of
+            base_batch_size and some scaling of the amplitude; therefore, upper_batch_size_bound may not actually be
+            reached depending on scaling function. If None or greater than the lenght of the dataset wrapped by the
+            dataloader, max_batch_size is set to `len(self.dataloader.dataset)`. Default: None.
         min_batch_size (int): Lower limit for the batch size which must be greater than 0. Default: 1.
         verbose (bool): If ``True``, prints a message to stdout for each update. Default: ``False``.
 
@@ -1263,21 +1256,17 @@ class CyclicBS(BSScheduler):
     .. _bckenstler/CLR: https://github.com/bckenstler/CLR
     """
 
-    def __init__(self, dataloader: DataLoader, base_batch_size: int, upper_batch_size_bound: int,
+    def __init__(self, dataloader: DataLoader, base_batch_size: Union[int, None] = None,
                  step_size_up: int = 2000, step_size_down: Union[int, None] = None, mode: str = 'triangular',
                  gamma: float = 1.0, scale_fn: Union[Callable[[int], float], None] = None, scale_mode: str = 'cycle',
                  batch_size_manager: Union[BatchSizeManager, None] = None, max_batch_size: Union[int, None] = None,
                  min_batch_size: int = 1, verbose: bool = False):
-        assert isinstance(base_batch_size, int) and base_batch_size > 0
-        assert isinstance(upper_batch_size_bound, int) and upper_batch_size_bound > base_batch_size
+        assert base_batch_size is None or (isinstance(base_batch_size, int) and base_batch_size >= min_batch_size)
         assert isinstance(step_size_up, int) and step_size_up > 0
         assert step_size_down is None or (isinstance(step_size_down, int) and step_size_down > 0)
         assert isinstance(gamma, float) and gamma > 0.0
         assert scale_fn is None or callable(scale_fn)
         assert scale_mode in ('cycle', 'iterations')
-
-        self.base_batch_size: int = base_batch_size
-        self.upper_batch_size_bound: int = upper_batch_size_bound
 
         if mode not in ('triangular', 'triangular2', 'exp_range') and scale_fn is None:
             raise ValueError("CyclicBS requires either a valid mode or passing a custom scale_fn.")
@@ -1294,6 +1283,8 @@ class CyclicBS(BSScheduler):
         self._init_scale_fn()
 
         super().__init__(dataloader, batch_size_manager, max_batch_size, min_batch_size, verbose)
+        self.base_batch_size: int = self.dataloader._base_batch_size if base_batch_size is None else base_batch_size
+        assert self.max_batch_size > self.base_batch_size
 
     def _init_scale_fn(self):
         if self._scale_fn_custom is not None:
@@ -1324,6 +1315,9 @@ class CyclicBS(BSScheduler):
         """ Returns the next batch size as an :class:`int`. The value of the batch size cycles from base_batch_size to
         upper_batch_size_bound and back, while being scaled at each iteration.
         """
+        if self.last_epoch == 0:  # Don't do anything at initialization.
+            return self.batch_size
+
         ratio = self.last_epoch / self.total_size
         cycle = math.floor(1 + ratio)
         x = 1.0 + ratio - cycle
@@ -1332,7 +1326,7 @@ class CyclicBS(BSScheduler):
         else:
             scale_factor = (x - 1) / (self.step_ratio - 1)
 
-        base_height = (self.upper_batch_size_bound - self.base_batch_size) * scale_factor
+        base_height = (self.max_batch_size - self.base_batch_size) * scale_factor
         if self.scale_mode == 'cycle':
             base_height *= self.scale_fn(cycle)
         else:
@@ -1373,6 +1367,8 @@ class CosineAnnealingBSWithWarmRestarts(BSScheduler):
     Args:
         dataloader (DataLoader): Wrapped dataloader.
         t_0 (int): The number of iterations for the first restart is t_0 + 1.
+        base_batch_size (Union[int, None]): The base batch size. If None, the base batch size will be retrieved from
+            the dataloader. Default: None.
         factor (int): The factor with which :math:`t_{i}` is increased after a restart. Default: 1.
         batch_size_manager (Union[BatchSizeManager, None]): If not None, a custom class which manages the batch size,
             which provides a getter and setter for the batch size. Default: None.
@@ -1400,21 +1396,20 @@ class CosineAnnealingBSWithWarmRestarts(BSScheduler):
         >>>         scheduler.step()
     """
 
-    def __init__(self, dataloader: DataLoader, t_0: int, factor: int = 1,
+    def __init__(self, dataloader: DataLoader, t_0: int, base_batch_size: Union[int, None] = None, factor: int = 1,
                  batch_size_manager: Union[BatchSizeManager, None] = None, max_batch_size: Union[int, None] = None,
                  min_batch_size: int = 1, verbose: bool = False):
         assert isinstance(t_0, int) and t_0 > 0
         assert isinstance(factor, int) and factor > 0
-
-        # Should we accept the base_batch_size and upper_batch_size as parameters, and use upper_batch_size instead of
-        # max batch size?
+        assert base_batch_size is None or (isinstance(base_batch_size, int) and base_batch_size >= min_batch_size)
 
         self.t_0: int = t_0
         self.t_i: int = t_0
         self.t_cur: int = 0
         self.factor: int = factor
         super().__init__(dataloader, batch_size_manager, max_batch_size, min_batch_size, verbose)
-        self.base_batch_size: int = self.dataloader._base_batch_size
+        self.base_batch_size: int = self.dataloader._base_batch_size if base_batch_size is None else base_batch_size
+        assert self.max_batch_size > self.base_batch_size
 
     def get_new_bs(self) -> int:
         """ Returns the next batch size as an :class:`int`. Increases the batch size from base batch size to maximum
@@ -1423,7 +1418,6 @@ class CosineAnnealingBSWithWarmRestarts(BSScheduler):
         increase the batch size instead of decreasing the learning rate. We clip the values to always remain within
         bound.
         """
-        # TODO: pass values!
         if self.last_epoch == 0:  # Don't do anything at initialization.
             return self.batch_size
 
@@ -1457,8 +1451,8 @@ class OneCycleBS(BSScheduler):
         total_steps (int): The total number of steps in the cycle.
         decay_percentage (float): The fraction of the cycle spend decreasing the batch size. 1 - decay_percentage will
             be spent increasing the batch size. Default: 0.3.
-        base_batch_size (Union[int, None]): The base_batch_size that should be used. If None, the base_batch_size of
-            the dataloader will be used. Default: None.
+        base_batch_size (Union[int, None]): The base batch size. If None, the base batch size will be retrieved from
+            the dataloader. Default: None.
         strategy (str): One of `cos`, `linear`. Specifies the strategy used for annealing the batch size, 'cos' for
             cosine annealing, 'linear' for linear annealing. Default: 'cos'.
         batch_size_manager (Union[BatchSizeManager, None]): If not None, a custom class which manages the batch size,
@@ -1492,7 +1486,7 @@ class OneCycleBS(BSScheduler):
         assert strategy in ('cos', 'linear')
 
         self.end_step_1: int = rint(total_steps * decay_percentage)
-        self.end_step_2: int = total_steps - self.end_step_1  # TODO: -1
+        self.end_step_2: int = total_steps - self.end_step_1
 
         self.strategy: str = strategy
         if strategy == 'cos':
@@ -1502,6 +1496,7 @@ class OneCycleBS(BSScheduler):
 
         super().__init__(dataloader, batch_size_manager, max_batch_size, min_batch_size, verbose)
         self.base_batch_size: int = self.dataloader._base_batch_size if base_batch_size is None else base_batch_size
+        assert self.max_batch_size > self.base_batch_size
 
     @staticmethod
     def _annealing_cos(start, end, percentage):

--- a/bs_scheduler/batch_size_schedulers.py
+++ b/bs_scheduler/batch_size_schedulers.py
@@ -987,11 +987,12 @@ class ChainedBSScheduler(BSScheduler):
         self.batch_size_manager: BatchSizeManager = batch_size_manger
         self.schedulers: Tuple[BSScheduler, ...] = tuple(schedulers)
         self._last_bs: int = self.schedulers[-1].last_bs
-        self.max_batch_size: int = self.schedulers[-1].max_batch_size
-        self.min_batch_size: int = self.schedulers[-1].min_batch_size
+        self.max_batch_size: int = max([x.max_batch_size for x in self.schedulers])
+        self.min_batch_size: int = min([x.min_batch_size for x in self.schedulers])
         self._finished: bool = False
+        # self.verbose: bool = False
+        # self.verbose: bool = 0
         self._init_get_new_bs()
-        # TODO: Validate that everything is initialized
 
     def step(self, **kwargs):
         """ Executes the step() function for all schedulers in order.

--- a/bs_scheduler/batch_size_schedulers.py
+++ b/bs_scheduler/batch_size_schedulers.py
@@ -918,6 +918,9 @@ class CosineAnnealingBS(BSScheduler):
                  min_batch_size: int = 1, verbose: bool = False):
         assert isinstance(total_iters, int) and total_iters > 1
 
+        # Should we accept the base_batch_size and upper_batch_size as parameters, and use upper_batch_size instead of
+        # max batch size?
+
         self.total_iters: int = total_iters
         super().__init__(dataloader, batch_size_manager, max_batch_size, min_batch_size, verbose)
         self.base_batch_size: int = self.dataloader._base_batch_size
@@ -1361,14 +1364,13 @@ class CyclicBS(BSScheduler):
 
 class CosineAnnealingBSWithWarmRestarts(BSScheduler):
     """ Similar to torch.optim.lr_scheduler.CosineAnnealingWarmRestarts which implements `SGDR: Stochastic Gradient
-    Descent with Warm Restarts`_.
-    # TODO: Explain a bit.
-    # For batch size, we perform reverse annealing and instead
-    of decreasing the batch size to min_batch_size we increase it to max_batch_size.
+    Descent with Warm Restarts`_. Unlike torch.optim.lr_scheduler.CosineAnnealingWarmRestarts, which decreases the
+    learning rate for :math:`t_{i}` iterations and then restarts, we increase the batch size from base_batch_size to
+    max_batch_size in :math:`t_{i} + 1` iterations, then the batch size is restarted.
 
     Args:
         dataloader (DataLoader): Wrapped dataloader.
-        t_0 (int): The number of iterations for the first restart.
+        t_0 (int): The number of iterations for the first restart is t_0 + 1.
         factor (int): The factor with which :math:`t_{i}` is increased after a restart. Default: 1.
         batch_size_manager (Union[BatchSizeManager, None]): If not None, a custom class which manages the batch size,
             which provides a getter and setter for the batch size. Default: None.
@@ -1401,6 +1403,9 @@ class CosineAnnealingBSWithWarmRestarts(BSScheduler):
                  min_batch_size: int = 1, verbose: bool = False):
         assert isinstance(t_0, int) and t_0 > 0
         assert isinstance(factor, int) and factor > 0
+
+        # Should we accept the base_batch_size and upper_batch_size as parameters, and use upper_batch_size instead of
+        # max batch size?
 
         self.t_0: int = t_0
         self.t_i: int = t_0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "bs_scheduler"
-version = "0.2.1"
+version = "0.3.0"
 requires-python = ">=3.9"
 description = "A PyTorch Dataloader compatible batch size scheduler library."
 readme = "README.md"

--- a/tests/test_CosineAnnealingBSWithWarmRestarts.py
+++ b/tests/test_CosineAnnealingBSWithWarmRestarts.py
@@ -1,0 +1,58 @@
+import unittest
+
+from bs_scheduler import CosineAnnealingBSWithWarmRestarts
+from tests.test_utils import create_dataloader, simulate_n_epochs, fashion_mnist, \
+    get_batch_sizes_across_epochs, BSTest
+
+
+class TestCosineAnnealingBS(BSTest):
+    def setUp(self):
+        self.base_batch_size = 64
+        self.dataset = fashion_mnist()
+        # TODO: Test multiple dataloaders: dataloader with workers, dataloaders with samplers, with drop last and
+        #  without drop last and so on.
+
+    def test_dataloader_lengths(self):
+        base_batch_size = 10
+        t_0 = 5
+        n_epochs = 60
+        max_batch_size = 100
+
+        dataloader = create_dataloader(self.dataset, batch_size=base_batch_size)
+        scheduler = CosineAnnealingBSWithWarmRestarts(dataloader, t_0=t_0, max_batch_size=max_batch_size)
+
+        epoch_lengths = simulate_n_epochs(dataloader, scheduler, n_epochs)
+        expected_batch_sizes = [10, 19, 41, 69, 91, 100] * 10
+        expected_lengths = self.compute_epoch_lengths(expected_batch_sizes, len(self.dataset), drop_last=False)
+        self.assertEqual(epoch_lengths, expected_lengths)
+
+    def test_dataloader_batch_size(self):
+        base_batch_size = 10
+        t_0 = 5
+        n_epochs = 60
+        max_batch_size = 100
+        dataloader = create_dataloader(self.dataset, batch_size=base_batch_size)
+        scheduler = CosineAnnealingBSWithWarmRestarts(dataloader, t_0=t_0, max_batch_size=max_batch_size)
+
+        batch_sizes = get_batch_sizes_across_epochs(dataloader, scheduler, n_epochs)
+        expected_batch_sizes = [10, 19, 41, 69, 91, 100] * 10
+
+        self.assertEqual(batch_sizes, expected_batch_sizes)
+
+    def test_loading_and_unloading(self):
+        dataloader = create_dataloader(self.dataset)
+        t_0 = 5
+        max_batch_size = 100
+        scheduler = CosineAnnealingBSWithWarmRestarts(dataloader, t_0=t_0, max_batch_size=max_batch_size)
+
+        self.reloading_scheduler(scheduler)
+        self.torch_save_and_load(scheduler)
+        scheduler.step()
+        self.assertEqual(scheduler.t_0, t_0)
+
+
+if __name__ == "__main__":
+    from multiprocessing import freeze_support
+
+    freeze_support()
+    unittest.main()

--- a/tests/test_CyclicBS.py
+++ b/tests/test_CyclicBS.py
@@ -16,17 +16,17 @@ class TestConstantBS(BSTest):
     def test_dataloader_batch_size_triangular(self):
         base_batch_size = 10
         dataloader = create_dataloader(self.dataset, batch_size=base_batch_size)
-        upper_batch_size_bound = 100
+        max_batch_size = 100
         step_size_up = 10
-        scheduler = CyclicBS(dataloader, base_batch_size=base_batch_size, upper_batch_size_bound=upper_batch_size_bound,
+        scheduler = CyclicBS(dataloader, base_batch_size=base_batch_size, max_batch_size=max_batch_size,
                              step_size_up=step_size_up, mode='triangular')
         n_epochs = 4 * step_size_up
 
         batch_sizes = get_batch_sizes_across_epochs(dataloader, scheduler, n_epochs)
 
-        step = rint((upper_batch_size_bound - base_batch_size) / step_size_up)
-        increasing_range = list(range(base_batch_size, upper_batch_size_bound, step))
-        decreasing_range = list(range(upper_batch_size_bound, base_batch_size, -step))
+        step = rint((max_batch_size - base_batch_size) / step_size_up)
+        increasing_range = list(range(base_batch_size, max_batch_size, step))
+        decreasing_range = list(range(max_batch_size, base_batch_size, -step))
         expected_batch_sizes = (increasing_range + decreasing_range) * 2
 
         self.assertEqual(batch_sizes, expected_batch_sizes)
@@ -34,17 +34,17 @@ class TestConstantBS(BSTest):
     def test_dataloader_batch_size_triangular2(self):
         base_batch_size = 10
         dataloader = create_dataloader(self.dataset, batch_size=base_batch_size)
-        upper_batch_size_bound = 100
+        max_batch_size = 100
         step_size_up = 10
-        scheduler = CyclicBS(dataloader, base_batch_size=base_batch_size, upper_batch_size_bound=upper_batch_size_bound,
+        scheduler = CyclicBS(dataloader, base_batch_size=base_batch_size, max_batch_size=max_batch_size,
                              step_size_up=step_size_up, mode='triangular2')
         n_epochs = 4 * step_size_up
 
         batch_sizes = get_batch_sizes_across_epochs(dataloader, scheduler, n_epochs)
 
-        step = rint((upper_batch_size_bound - base_batch_size) / step_size_up)
-        increasing_range = list(range(base_batch_size, upper_batch_size_bound, step))
-        decreasing_range = list(range(upper_batch_size_bound, base_batch_size, -step))
+        step = rint((max_batch_size - base_batch_size) / step_size_up)
+        increasing_range = list(range(base_batch_size, max_batch_size, step))
+        decreasing_range = list(range(max_batch_size, base_batch_size, -step))
         increasing_range_2 = [base_batch_size]
         for _ in range(step_size_up - 1):
             increasing_range_2.append(increasing_range_2[-1] + step / 2.0)
@@ -65,10 +65,10 @@ class TestConstantBS(BSTest):
     def test_dataloader_batch_size_exp_range(self):
         base_batch_size = 10
         dataloader = create_dataloader(self.dataset, batch_size=base_batch_size)
-        upper_batch_size_bound = 100
+        max_batch_size = 100
         step_size_up = 10
         gamma = 0.9
-        scheduler = CyclicBS(dataloader, base_batch_size=base_batch_size, upper_batch_size_bound=upper_batch_size_bound,
+        scheduler = CyclicBS(dataloader, base_batch_size=base_batch_size, max_batch_size=max_batch_size,
                              step_size_up=step_size_up, mode='exp_range', gamma=gamma)
         n_epochs = 4 * step_size_up
 
@@ -88,7 +88,7 @@ class TestConstantBS(BSTest):
 
             return increasing_range, decreasing_range, count
 
-        step = rint((upper_batch_size_bound - base_batch_size) / step_size_up)
+        step = rint((max_batch_size - base_batch_size) / step_size_up)
         count = 0
 
         increasing_range, decreasing_range, count = calculate_increasing_and_decreasing_range(

--- a/tests/test_SequentialBS.py
+++ b/tests/test_SequentialBS.py
@@ -85,15 +85,6 @@ class TestSequentialBS(BSTest):
             SequentialBS(dataloader, schedulers=[other_scheduler, scheduler2, scheduler3], milestones=[5, 10],
                          max_batch_size=100)
 
-        with self.assertRaises(ValueError):
-            other_scheduler = ConstantBS(dataloader, factor=10, milestone=4, max_batch_size=555)
-            SequentialBS(dataloader, schedulers=[other_scheduler, scheduler2, scheduler3], milestones=[5, 10],
-                         max_batch_size=100)
-        with self.assertRaises(ValueError):
-            other_scheduler = ConstantBS(dataloader, factor=10, milestone=4, min_batch_size=2)
-            SequentialBS(dataloader, schedulers=[other_scheduler, scheduler2, scheduler3], milestones=[5, 10],
-                         max_batch_size=100)
-
     def test_loading_and_unloading(self):
         dataloader = create_dataloader(self.dataset)
         factor = 10

--- a/tests/test_SequentialBS.py
+++ b/tests/test_SequentialBS.py
@@ -20,7 +20,7 @@ class TestSequentialBS(BSTest):
         dataloader = create_dataloader(self.dataset, batch_size=base_batch_size)
         scheduler1 = ConstantBS(dataloader, factor=10, milestone=4)
         scheduler2 = ExponentialBS(dataloader, gamma=1.1)
-        scheduler = SequentialBS(dataloader, schedulers=[scheduler1, scheduler2], milestones=[5])
+        scheduler = SequentialBS(schedulers=[scheduler1, scheduler2], milestones=[5])
         n_epochs = 10
 
         epoch_lengths = simulate_n_epochs(dataloader, scheduler, n_epochs)
@@ -33,7 +33,7 @@ class TestSequentialBS(BSTest):
         dataloader = create_dataloader(self.dataset, batch_size=base_batch_size)
         scheduler1 = ConstantBS(dataloader, factor=10, milestone=4, max_batch_size=100)
         scheduler2 = ExponentialBS(dataloader, gamma=2, max_batch_size=100, verbose=False)
-        scheduler = SequentialBS(dataloader, schedulers=[scheduler1, scheduler2], milestones=[5], max_batch_size=100)
+        scheduler = SequentialBS(schedulers=[scheduler1, scheduler2], milestones=[5])
         n_epochs = 10
 
         batch_sizes = get_batch_sizes_across_epochs(dataloader, scheduler, n_epochs)
@@ -48,29 +48,25 @@ class TestSequentialBS(BSTest):
         scheduler3 = LinearBS(dataloader, max_batch_size=100, verbose=False)
         if len(os.getenv('PYTHONOPTIMIZE', '')) == 0:
             with self.assertRaises(AssertionError):
-                SequentialBS(dataloader, schedulers=scheduler1, milestones=[5], max_batch_size=100)
+                SequentialBS(schedulers=scheduler1, milestones=[5])
             with self.assertRaises(AssertionError):
-                SequentialBS(dataloader, schedulers=[scheduler1], milestones=[5], max_batch_size=100)
+                SequentialBS(schedulers=[scheduler1], milestones=[5])
             with self.assertRaises(AssertionError):
-                SequentialBS(dataloader, schedulers=[scheduler1, scheduler2], milestones=5, max_batch_size=100)
+                SequentialBS(schedulers=[scheduler1, scheduler2], milestones=5)
             with self.assertRaises(AssertionError):
-                SequentialBS(dataloader, schedulers=[scheduler1, scheduler2], milestones=[], max_batch_size=100)
+                SequentialBS(schedulers=[scheduler1, scheduler2], milestones=[])
             with self.assertRaises(AssertionError):
-                SequentialBS(dataloader, schedulers=[scheduler1, scheduler2], milestones=[0], max_batch_size=100)
+                SequentialBS(schedulers=[scheduler1, scheduler2], milestones=[0])
             with self.assertRaises(AssertionError):
-                SequentialBS(dataloader, schedulers=[scheduler1, scheduler2, scheduler3], milestones=[10, 5],
-                             max_batch_size=100)
+                SequentialBS(schedulers=[scheduler1, scheduler2, scheduler3], milestones=[10, 5])
             with self.assertRaises(ValueError):
-                SequentialBS(dataloader, schedulers=[scheduler1, scheduler2, scheduler3], milestones=[10],
-                             max_batch_size=100)
+                SequentialBS(schedulers=[scheduler1, scheduler2, scheduler3], milestones=[10])
 
-        SequentialBS(dataloader, schedulers=[scheduler1, scheduler2, scheduler3], milestones=[5, 10],
-                     max_batch_size=100)
+        SequentialBS(schedulers=[scheduler1, scheduler2, scheduler3], milestones=[5, 10])
         with self.assertRaises(ValueError):
             other_dataloader = create_dataloader(self.dataset, batch_size=self.base_batch_size)
             other_scheduler = ConstantBS(other_dataloader, factor=10, milestone=4, max_batch_size=100)
-            SequentialBS(dataloader, schedulers=[other_scheduler, scheduler2, scheduler3], milestones=[5, 10],
-                         max_batch_size=100)
+            SequentialBS(schedulers=[other_scheduler, scheduler2, scheduler3], milestones=[5, 10])
 
         with self.assertRaises(ValueError):
             class OtherBatchManager(BatchSizeManager):
@@ -82,15 +78,14 @@ class TestSequentialBS(BSTest):
 
             other_scheduler = ConstantBS(dataloader, factor=10, milestone=4, max_batch_size=100,
                                          batch_size_manager=OtherBatchManager())
-            SequentialBS(dataloader, schedulers=[other_scheduler, scheduler2, scheduler3], milestones=[5, 10],
-                         max_batch_size=100)
+            SequentialBS(schedulers=[other_scheduler, scheduler2, scheduler3], milestones=[5, 10])
 
     def test_loading_and_unloading(self):
         dataloader = create_dataloader(self.dataset)
         factor = 10
         scheduler1 = ConstantBS(dataloader, factor=factor, milestone=4)
         scheduler2 = ExponentialBS(dataloader, gamma=2, verbose=False)
-        scheduler = SequentialBS(dataloader, schedulers=[scheduler1, scheduler2], milestones=[5])
+        scheduler = SequentialBS(schedulers=[scheduler1, scheduler2], milestones=[5])
 
         self.reloading_scheduler(scheduler)
         self.torch_save_and_load(scheduler)


### PR DESCRIPTION
## API breaking changes: 
  * The upper_batch_size_bound argument of `CyclicBS` was removed and the max_batch_size parameter is used instead.
  * Removed redundant arguments from `SequentialBS`: dataloader, batch_size_manager, max_batch_size, min_batch_size and verbose. They are now retrieved from the first available schedulers.
  
## Other changes:
  * `SequentialBS` does not raises errors if the schedulers that are passed do not have the same maximum and minimum batch size.
  * The maximum and minimum batch size of `SequentialBS` is set by taking the minimum and maximum value from the list of schedulers passed to it. 
  * `CosineAnnealingBS` now accepts an optional base_batch_size argument which can override the base_batch_size from the wrapped dataloader. 
  * The base_batch_size argument of `CyclicBS` was made optional. If not provided, the base_batch_size from the wrapped dataloader will be used instead.
  * The implementation of `CyclicBS` was updated to not do anything during the first step.
  * The initialization of min_batch_size, max_batch_size and batch_size_manager from `BSScheduler` is now clearer. 
  * The max_batch_size and min_batch_size from `ChainedBSScheduler` are set to the maximum and the minimum from all schedulers.
  * The assertion checks, the documentation and tests were updated accordingly. 
  * Bumping version.