### PR TITLE
Fixed bug when the cosine period of `CosineAnnealingBS` is larger

### DIFF
--- a/bs_scheduler/batch_size_schedulers.py
+++ b/bs_scheduler/batch_size_schedulers.py
@@ -913,6 +913,7 @@ class CosineAnnealingBS(BSScheduler):
         super().__init__(dataloader, batch_size_manager, max_batch_size, min_batch_size, verbose)
         self.base_batch_size: int = self.dataloader._base_batch_size if base_batch_size is None else base_batch_size
         assert self.max_batch_size > self.base_batch_size
+        self._float_batch_size: float = self.base_batch_size
 
     def get_new_bs(self) -> int:
         """ Returns the next batch size as an :class:`int`. Increases the batch size from base batch size to maximum
@@ -930,14 +931,11 @@ class CosineAnnealingBS(BSScheduler):
             new_bs = self.batch_size + (self.base_batch_size - self.max_batch_size) * (
                     1 - math.cos(math.pi / self.total_iters)) / 2
         else:
-            if self.batch_size == self.max_batch_size and self.last_epoch % self.total_iters < self.total_iters / 2:
-                bs_diff = -1
-            else:
-                bs_diff = self.batch_size - self.max_batch_size
-
             new_bs = (1 + math.cos(math.pi * self.last_epoch / self.total_iters)) / (
-                    1 + math.cos(math.pi * (self.last_epoch - 1) / self.total_iters)) * bs_diff + self.max_batch_size
+                    1 + math.cos(math.pi * (self.last_epoch - 1) / self.total_iters)) * (
+                    self._float_batch_size - self.max_batch_size) + self.max_batch_size
 
+        self._float_batch_size = new_bs
         return clip(rint(new_bs), min=self.base_batch_size, max=self.max_batch_size)
 
 

--- a/bs_scheduler/batch_size_schedulers.py
+++ b/bs_scheduler/batch_size_schedulers.py
@@ -930,9 +930,13 @@ class CosineAnnealingBS(BSScheduler):
             new_bs = self.batch_size + (self.base_batch_size - self.max_batch_size) * (
                     1 - math.cos(math.pi / self.total_iters)) / 2
         else:
+            if self.batch_size == self.max_batch_size and self.last_epoch % self.total_iters < self.total_iters / 2:
+                bs_diff = -1
+            else:
+                bs_diff = self.batch_size - self.max_batch_size
+
             new_bs = (1 + math.cos(math.pi * self.last_epoch / self.total_iters)) / (
-                    1 + math.cos(math.pi * (self.last_epoch - 1) / self.total_iters)) * (
-                             self.batch_size - self.max_batch_size) + self.max_batch_size
+                    1 + math.cos(math.pi * (self.last_epoch - 1) / self.total_iters)) * bs_diff + self.max_batch_size
 
         return clip(rint(new_bs), min=self.base_batch_size, max=self.max_batch_size)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "bs_scheduler"
-version = "0.3.1"
+version = "0.3.2"
 requires-python = ">=3.9"
 description = "A PyTorch Dataloader compatible batch size scheduler library."
 readme = "README.md"

--- a/tests/test_CosineAnnealingBS.py
+++ b/tests/test_CosineAnnealingBS.py
@@ -22,20 +22,24 @@ class TestCosineAnnealingBS(BSTest):
         scheduler = CosineAnnealingBS(dataloader, total_iters=total_iters, max_batch_size=max_batch_size)
 
         epoch_lengths = simulate_n_epochs(dataloader, scheduler, n_epochs)
-        expected_batch_sizes = [10, 19, 41, 69, 91, 100, 91, 67, 37, 13] * 5
+        expected_batch_sizes = [10, 19, 41, 69, 91, 100, 91, 69, 41, 19] * 5
         expected_lengths = self.compute_epoch_lengths(expected_batch_sizes, len(self.dataset), drop_last=False)
         self.assertEqual(epoch_lengths, expected_lengths)
 
     def test_dataloader_batch_size(self):
         base_batch_size = 10
-        total_iters = 5
-        n_epochs = 50
+        total_iters = 50
+        n_epochs = 500
         max_batch_size = 100
         dataloader = create_dataloader(self.dataset, batch_size=base_batch_size)
         scheduler = CosineAnnealingBS(dataloader, total_iters=total_iters, max_batch_size=max_batch_size)
 
         batch_sizes = get_batch_sizes_across_epochs(dataloader, scheduler, n_epochs)
-        expected_batch_sizes = [10, 19, 41, 69, 91, 100, 91, 67, 37, 13] * 5
+        expected_batch_sizes = [10, 10, 10, 11, 11, 12, 13, 14, 16, 17, 19, 20, 22, 24, 26, 29, 31, 33, 36, 38, 41, 44,
+                                47, 49, 52, 55, 58, 61, 63, 66, 69, 72, 74, 77, 79, 81, 84, 86, 88, 90, 91, 93, 94, 96,
+                                97, 98, 99, 99, 100, 100, 100, 100, 100, 99, 99, 98, 97, 96, 94, 93, 91, 90, 88, 86, 84,
+                                81, 79, 77, 74, 72, 69, 66, 63, 61, 58, 55, 52, 49, 47, 44, 41, 38, 36, 33, 31, 29, 26,
+                                24, 22, 20, 19, 17, 16, 14, 13, 12, 11, 11, 10, 10] * 5
 
         self.assertEqual(batch_sizes, expected_batch_sizes)
 


### PR DESCRIPTION
* When the cosine period is larger and the scheduler does not modifies it's batch size by more than 1 unit each `2 * total_iters` steps, the scheduler remains blocked in the maximum batch size. 
* The solution is to use an additional member variable which keeps track of the unrounded value of the batch size from the previous step. 
* This solution also improves stability, making the cosine wave symmetric on both sides.
* Bumping version.